### PR TITLE
Fix client_type checking bug in oauth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *.egg-info
+*.swp
 __pycache__
 build
 develop-eggs

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -432,11 +432,11 @@ class OAuth2RequestValidator(RequestValidator):
             log.debug('Authenticate client failed, secret not match.')
             return False
 
-        confidential = 'confidential'
-        if hasattr(client, 'confidential'):
-            confidential = client.confidential
+        client_type = 'confidential'
+        if hasattr(client, 'client_type'):
+            client_type = client.client_type
 
-        if client.client_type != confidential:
+        if client.client_type != client_type:
             log.debug('Authenticate client failed, not confidential.')
             return False
         log.debug('Authenticate client success.')
@@ -459,11 +459,11 @@ class OAuth2RequestValidator(RequestValidator):
 
         # authenticate non-confidential client_type only
         # most of the clients are of public client_type
-        confidential = 'confidential'
-        if hasattr(client, 'confidential'):
-            confidential = client.confidential
+        client_type = 'confidential'
+        if hasattr(client, 'client_type'):
+            client_type = client.client_type
 
-        if client.client_type == confidential:
+        if client.client_type == client_type:
             log.debug('Authenticate client failed, confidential client.')
             return False
         return True


### PR DESCRIPTION
- Fixed a bug in both authentication methods where checking client_type was being done improperly, thus defaulting to 'confidential' even if 'client_type' was set to 'public'. There is no mention of the 'confidential' attribute in clientgetter(), I believe you meant to check 'client_type' instead.
- Added swp extension to .gitignore
