### PR TITLE
Possible fix for pull request #17

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -12,7 +12,6 @@ import os
 import logging
 import datetime
 from functools import wraps
-from flask import _app_ctx_stack
 from flask import request, url_for
 from flask import redirect, make_response, abort
 from werkzeug import cached_property


### PR DESCRIPTION
#17 raised a good point. The client doesn't need to have an confidential attribute when it already has a client_type (they both would contain the same data). Therefore there should only be one check `if client.client_type == 'confidential'`
