### PR TITLE
Minor documentation change

### DIFF
--- a/docs/provider.rst
+++ b/docs/provider.rst
@@ -265,6 +265,10 @@ implemented with decorators::
             user=get_current_user(),
             expires=expires
         )
+        db.session.add(grant)
+        db.session.commit()
+        return grant
+
 
 In the sample code, there is a ``get_current_user`` method, that will return
 the current user object, you should implement it yourself.


### PR DESCRIPTION
I propose a minor documentation change to documenting saving the grant to the database in the provider @oauth.grantsetter. This brings it in line with the example for tokensetter.

If this isn't needed, please reject my change.

Thank you,

Tom
