### PR TITLE
Update request hook docs with a working example to get the consumer key

### DIFF
--- a/docs/additional.rst
+++ b/docs/additional.rst
@@ -13,7 +13,11 @@ before_request::
 
     @oauth.before_request
     def limit_client_request():
-        client_id = request.values.get('client_id')
+        from flask_oauthlib.utils import extract_params
+        uri, http_method, body, headers = extract_params()
+        request = oauth._create_request(uri, http_method, body, headers)
+
+        client_id = request.client_key
         if not client_id:
             return
         client = Client.get(client_id)


### PR DESCRIPTION
Simple update to the docs that provides a good example of how to access the oauth headers. @lepture suggested an improvement to provide a helper on the OAuth1Provider object that would create the request object which would reduce the need to create the request multiple times.

This resolves the issue I raised in #45, but perhaps there's more work to create that helper.
