### PR TITLE
Add support for OAuth2 state parameter

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -437,10 +437,13 @@ class OAuthRemoteApp(object):
         )
         return OAuthResponse(resp, content, self.content_type)
 
-    def authorize(self, callback=None):
+    def authorize(self, callback=None, state=None):
         """
         Returns a redirect response to the remote authorization URL with
         the signed callback given.
+
+        :param state: an optional value to embed in the OAuth request. Use this
+        if you want to pass around application state (e.g. CSRF tokens).
         """
         if self.request_token_url:
             token = self.generate_request_token(callback)[0]
@@ -467,6 +470,7 @@ class OAuthRemoteApp(object):
                 self.expand_url(self.authorize_url),
                 redirect_uri=callback,
                 scope=scope,
+                state=state,
                 **params
             )
         return redirect(url)


### PR DESCRIPTION
The state parameter is useful for relaying application-specific parameters to the code. It's hard-coded to None right now, but it is useful to have this option in the authorize callback since the value can change.

For more details:

https://developers.google.com/accounts/docs/OAuth2InstalledApp
