### PR TITLE
fix for post data type error in py3.

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -572,6 +572,8 @@ class OAuthRemoteApp(object):
         remote_args.update(self.access_token_params)
         if self.access_token_method == 'POST':
             body = client.prepare_request_body(**remote_args)
+            if PY3:
+                body = body.encode('utf-8')
             resp, content = self.http_request(
                 self.expand_url(self.access_token_url),
                 data=body,


### PR DESCRIPTION
Env:
python 3.3.3

Reproduce:

``` bash
$ python google.py
```

`TypeError` raised for `/login/authorized`

``` python
Traceback (most recent call last):
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/lxyu/.dotfiles/.virtualenvs/py3/lib/python3.3/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/lxyu/Workspace/lxyu/flask-oauthlib/flask_oauthlib/client.py", line 616, in decorated
    data = self.handle_oauth2_response()
  File "/Users/lxyu/Workspace/lxyu/flask-oauthlib/flask_oauthlib/client.py", line 578, in handle_oauth2_response
    method=self.access_token_method,
  File "/Users/lxyu/Workspace/lxyu/flask-oauthlib/flask_oauthlib/client.py", line 347, in http_request
    resp = http.urlopen(req)
  File "/usr/local/Cellar/python3/3.3.3/Frameworks/Python.framework/Versions/3.3/lib/python3.3/urllib/request.py", line 156, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/Cellar/python3/3.3.3/Frameworks/Python.framework/Versions/3.3/lib/python3.3/urllib/request.py", line 467, in open
    req = meth(req)
  File "/usr/local/Cellar/python3/3.3.3/Frameworks/Python.framework/Versions/3.3/lib/python3.3/urllib/request.py", line 1179, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```
