### PR TITLE
Branch:dec - adding return statement to all the decorator func

### DIFF
--- a/flask_oauthlib/provider/oauth1.py
+++ b/flask_oauthlib/provider/oauth1.py
@@ -151,6 +151,7 @@ class OAuth1Provider(object):
                 track_request(client)
         """
         self._before_request_funcs.append(f)
+        return f
 
     def after_request(self, f):
         """Register functions to be invoked after accessing the resource.
@@ -165,6 +166,7 @@ class OAuth1Provider(object):
                 return valid, oauth
         """
         self._after_request_funcs.append(f)
+        return f
 
     def clientgetter(self, f):
         """Register a function as the client getter.
@@ -190,6 +192,7 @@ class OAuth1Provider(object):
                 return client
         """
         self._clientgetter = f
+        return f
 
     def tokengetter(self, f):
         """Register a function as the access token getter.
@@ -210,6 +213,7 @@ class OAuth1Provider(object):
                 return AccessToken.get(client_key=client_key, token=token)
         """
         self._tokengetter = f
+        return f
 
     def tokensetter(self, f):
         """Register a function as the access token setter.
@@ -243,6 +247,7 @@ class OAuth1Provider(object):
             - request_token: Requst token for exchanging this access token
         """
         self._tokensetter = f
+        return f
 
     def grantgetter(self, f):
         """Register a function as the request token getter.
@@ -263,6 +268,7 @@ class OAuth1Provider(object):
                 return RequestToken.get(token=token)
         """
         self._grantgetter = f
+        return f
 
     def grantsetter(self, f):
         """Register a function as the request token setter.
@@ -281,6 +287,7 @@ class OAuth1Provider(object):
                 return data.save()
         """
         self._grantsetter = f
+        return f
 
     def noncegetter(self, f):
         """Register a function as the nonce and timestamp getter.
@@ -301,6 +308,7 @@ class OAuth1Provider(object):
                 return Nonce.get("...")
         """
         self._noncegetter = f
+        return f
 
     def noncesetter(self, f):
         """Register a function as the nonce and timestamp setter.
@@ -317,6 +325,7 @@ class OAuth1Provider(object):
         if you put timestamp and nonce object in a cache.
         """
         self._noncesetter = f
+        return f
 
     def verifiergetter(self, f):
         """Register a function as the verifier getter.
@@ -335,6 +344,7 @@ class OAuth1Provider(object):
                 return data
         """
         self._verifiergetter = f
+        return f
 
     def verifiersetter(self, f):
         """Register a function as the verifier setter.
@@ -356,6 +366,7 @@ class OAuth1Provider(object):
                 return data.save()
         """
         self._verifiersetter = f
+        return f
 
     def authorize_handler(self, f):
         """Authorization handler decorator.

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -182,6 +182,7 @@ class OAuth2Provider(object):
                 track_request(client)
         """
         self._before_request_funcs.append(f)
+        return f
 
     def after_request(self, f):
         """Register functions to be invoked after accessing the resource.
@@ -196,6 +197,7 @@ class OAuth2Provider(object):
                 return valid, oauth
         """
         self._after_request_funcs.append(f)
+        return f
 
     def clientgetter(self, f):
         """Register a function as the client getter.
@@ -225,6 +227,7 @@ class OAuth2Provider(object):
                 return client
         """
         self._clientgetter = f
+        return f
 
     def usergetter(self, f):
         """Register a function as the user getter.
@@ -238,6 +241,7 @@ class OAuth2Provider(object):
                 return get_user_by_username(username, password)
         """
         self._usergetter = f
+        return f
 
     def tokengetter(self, f):
         """Register a function as the token getter.
@@ -264,6 +268,7 @@ class OAuth2Provider(object):
                 return None
         """
         self._tokengetter = f
+        return f
 
     def tokensetter(self, f):
         """Register a function to save the bearer token.
@@ -288,6 +293,7 @@ class OAuth2Provider(object):
         client object.
         """
         self._tokensetter = f
+        return f
 
     def grantgetter(self, f):
         """Register a function as the grant getter.
@@ -303,6 +309,7 @@ class OAuth2Provider(object):
             - delete: A function to delete itself
         """
         self._grantgetter = f
+        return f
 
     def grantsetter(self, f):
         """Register a function to save the grant code.
@@ -314,6 +321,7 @@ class OAuth2Provider(object):
                 save_grant(client_id, code, request.user, request.scopes)
         """
         self._grantsetter = f
+        return f
 
     def authorize_handler(self, f):
         """Authorization handler decorator.


### PR DESCRIPTION
## Bug

The client/token _getter_ and _setters_ in oauth provider 1 & 2 makes the original function not callable
## Reproduce

Steps:

```
from . import oauth  #the oauth server object
@oauth.grantgetter
def load_request_token(token):
     print 'abc'
     return 1

if __name__ == '__main__':
    load_request_token('cba')
```

Expectation:
Running the script will print out `abc`

Reality:
Won't be able to call load_request_token
## Solution

Add `return f` to all the _getter_ and _setter_ in the providers
## Reference

Flask's _getter_ decorator also return the f:

```
@setupmethod
def before_request(self, f):
    """Registers a function to run before each request."""
    self.before_request_funcs.setdefault(None, []).append(f)
    return f
```

https://github.com/mitsuhiko/flask/blob/master/flask/app.py#L1194
## Test result

```
(flask-oauthlib)davislx@vm-0:~/Github/flask-oauthlib$ nosetests                                                                                                                                              
..................................................................
----------------------------------------------------------------------
Ran 66 tests in 194.731s
OK
```
