### PR TITLE
Add the ability to pass additional URL parameters to the authorize() call

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -449,7 +449,7 @@ class OAuthRemoteApp(object):
         :param state: an optional value to embed in the OAuth request.
                       Use this if you want to pass around application
                       state (e.g. CSRF tokens).
-		:param kwargs: add optional key/value pairs to the query string
+        :param kwargs: add optional key/value pairs to the query string
         """
         if self.request_token_url:
             token = self.generate_request_token(callback)[0]


### PR DESCRIPTION
Hello,

I've modified the authorize() call to allow for additional URL parameters that you may not want to include in the request_token_params instance variable.  This allows you to have one OAuthRemoteApp instance that can be used with a variety of query parameters.  For example, with Google OAuth, I'm able to pass prompt="none" for authentication only, and prompt="consent" when I want to prompt the user for access.

Please let me know if you have any questions about my use case or the changes themselves.

-Scott
