### PR TITLE
Fix issue with different methods used for signing and requesting access token

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -557,7 +557,8 @@ class OAuthRemoteApp(object):
         )
 
         resp, content = self.http_request(
-            uri, headers, to_bytes(data, self.encoding)
+            uri, headers, to_bytes(data, self.encoding),
+            method=self.access_token_method
         )
         data = parse_response(resp, content)
         if resp.code not in (200, 201):


### PR DESCRIPTION
In the OAuthV1 code that requests an access token, signatures are generated using the request method (among other parameters).  

Without the fix, when the request method (access_token_method property) is set to 'POST', then the signature is generated using 'POST', but the request is made with 'GET'.  This causes a signature mismatch, and the OAuthV1 provider throws an error.

This quick fix passes the method along when requesting an access token, fixing the mismatch.
