### PR TITLE
Fix client_credentials logic in validate_grant_type

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -705,15 +705,16 @@ class OAuth2RequestValidator(RequestValidator):
                               'client_credentials', 'refresh_token'):
             return False
 
-        if hasattr(client, 'allowed_grant_types'):
-            return grant_type in client.allowed_grant_types
+        if (hasattr(client, 'allowed_grant_types') and
+                grant_type not in client.allowed_grant_types):
+            return False
 
         if grant_type == 'client_credentials':
             if hasattr(client, 'user'):
                 request.user = client.user
-                return True
-            log.debug('Client should has a user property')
-            return False
+            else:
+                log.debug('Client should have a user property')
+                return False
 
         return True
 

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -51,6 +51,11 @@ class Client(db.Model):
             return self.default_scope.split()
         return []
 
+    @property
+    def allowed_grant_types(self):
+        return ['authorization_code', 'password', 'client_credentials',
+                'refresh_token']
+
 
 class Grant(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
request.user was never set since grant_type was valid in the implemented allowed_grant_types method.

This also updates the Client-model in oauth2-test to include allowed_grant_types to be sure that this fixes the bug.
