### PR TITLE
Support client authentication for authorization-code grant type

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -464,7 +464,24 @@ class OAuth2RequestValidator(RequestValidator):
         self._grantsetter = grantsetter
 
     def client_authentication_required(self, request, *args, **kwargs):
-        return request.grant_type in ('password', 'refresh_token')
+        """Determine if client authentication is required for current request.
+
+        According to the rfc6749, client authentication is required in the
+        following cases:
+
+        Resource Owner Password Credentials Grant: see `Section 4.3.2`_.
+        Authorization Code Grant: see `Section 4.1.3`_.
+        Refresh Token Grant: see `Section 6`_.
+
+        .. _`Section 4.3.2`: http://tools.ietf.org/html/rfc6749#section-4.3.2
+        .. _`Section 4.1.3`: http://tools.ietf.org/html/rfc6749#section-4.1.3
+        .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
+        """
+        if request.grant_type == 'password':
+            return True
+        auth_required = ('authorization_code', 'refresh_token')
+        return 'Authorization' in request.headers and\
+                request.grant_type in auth_required
 
     def authenticate_client(self, request, *args, **kwargs):
         """Authenticate itself in other means.
@@ -494,6 +511,7 @@ class OAuth2RequestValidator(RequestValidator):
             return False
 
         request.client = client
+
         if client.client_secret != client_secret:
             log.debug('Authenticate client failed, secret not match.')
             return False
@@ -529,9 +547,10 @@ class OAuth2RequestValidator(RequestValidator):
         add a `validate_redirect_uri` function on grant for a customized
         validation.
         """
+        client = client or self._clientgetter(client_id)
         log.debug('Confirm redirect uri for client %r and code %r.',
-                  client_id, code)
-        grant = self._grantgetter(client_id=client_id, code=code)
+                  client.client_id, code)
+        grant = self._grantgetter(client_id=client.client_id, code=code)
         if not grant:
             log.debug('Grant not found.')
             return False
@@ -668,10 +687,11 @@ class OAuth2RequestValidator(RequestValidator):
 
     def validate_code(self, client_id, code, client, request, *args, **kwargs):
         """Ensure the grant code is valid."""
+        client = client or self._clientgetter(client_id)
         log.debug(
-            'Validate code for client %r and code %r', client_id, code
+            'Validate code for client %r and code %r', client.client_id, code
         )
-        grant = self._grantgetter(client_id=client_id, code=code)
+        grant = self._grantgetter(client_id=client.client_id, code=code)
         if not grant:
             log.debug('Grant not found.')
             return False

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -217,10 +217,17 @@ def prepare_app(app):
 
     user = User(username='admin')
 
+    temp_grant = Grant(
+        user_id=1, client_id='confidential',
+        code='12345', scope='email',
+        expires=datetime.utcnow() + timedelta(seconds=100)
+    )
+
     try:
         db.session.add(client1)
         db.session.add(client2)
         db.session.add(user)
+        db.session.add(temp_grant)
         db.session.commit()
     except:
         db.session.rollback()

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -297,3 +297,33 @@ class TestTokenGenerator(OAuthSuite):
         data = json.loads(u(rv.data))
         assert data['access_token'] == 'foobar'
         assert data['refresh_token'] == 'foobar'
+
+
+class TestConfidentialClient(OAuthSuite):
+
+    def create_oauth_provider(self, app):
+        return default_provider(app)
+
+    def test_get_access_token(self):
+        url = ('/oauth/token?grant_type=authorization_code&code=12345'
+               '&scope=email')
+        rv = self.client.get(url, headers={
+            'Authorization': 'Basic %s' % auth_code
+        }, data={'confirm': 'yes'})
+        assert b'access_token' in rv.data
+
+    def test_invalid_grant(self):
+        url = ('/oauth/token?grant_type=authorization_code&code=54321'
+               '&scope=email')
+        rv = self.client.get(url, headers={
+            'Authorization': 'Basic %s' % auth_code
+        }, data={'confirm': 'yes'})
+        assert b'invalid_grant' in rv.data
+
+    def test_invalid_client(self):
+        url = ('/oauth/token?grant_type=authorization_code&code=12345'
+               '&scope=email')
+        rv = self.client.get(url, headers={
+            'Authorization': 'Basic %s' % ('foo')
+        }, data={'confirm': 'yes'})
+        assert b'invalid_client' in rv.data


### PR DESCRIPTION
When using a confidential client it should be possible to obtain a token through authorization code grant type with a valid code.

In some cases you want to authenticate the client when using authorization code grant type. Though as it is implemented now you to have the client_id in the body. Which is not really required when a token was obtained with client_credentials... I'm not 100% sure on how this should be, but at least authorization_code is working with non-confidential clients also with this implementation.

https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/request_validator.py#L22
