### PR TITLE
fix mod_wsgi unicode header error, ensure header names are bytes encoded...

### DIFF
--- a/flask_oauthlib/utils.py
+++ b/flask_oauthlib/utils.py
@@ -38,7 +38,7 @@ def create_response(headers, body, status):
     """Create response class for Flask."""
     response = Response(body or '')
     for k, v in headers.items():
-        response.headers[to_bytes(k)] = v
+        response.headers[str(k)] = v
 
     response.status_code = status
     return response


### PR DESCRIPTION
This seems to be related to https://github.com/lepture/flask-oauthlib/issues/84 where mod_wsgi throws an error if it gets Unicode header names.
