### PR TITLE
Don’t cache remote properties

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -15,7 +15,7 @@ from functools import wraps
 from oauthlib.common import to_unicode, PY3, add_params_to_uri
 from flask import request, redirect, json, session, current_app
 from werkzeug import url_quote, url_decode, url_encode
-from werkzeug import parse_options_header, cached_property
+from werkzeug import parse_options_header
 from .utils import to_bytes
 try:
     from urlparse import urljoin
@@ -251,43 +251,43 @@ class OAuthRemoteApp(object):
         self.app_key = app_key
         self.encoding = encoding
 
-    @cached_property
+    @property
     def base_url(self):
         return self._get_property('base_url')
 
-    @cached_property
+    @property
     def request_token_url(self):
         return self._get_property('request_token_url', None)
 
-    @cached_property
+    @property
     def access_token_url(self):
         return self._get_property('access_token_url')
 
-    @cached_property
+    @property
     def authorize_url(self):
         return self._get_property('authorize_url')
 
-    @cached_property
+    @property
     def consumer_key(self):
         return self._get_property('consumer_key')
 
-    @cached_property
+    @property
     def consumer_secret(self):
         return self._get_property('consumer_secret')
 
-    @cached_property
+    @property
     def request_token_params(self):
         return self._get_property('request_token_params', {})
 
-    @cached_property
+    @property
     def access_token_params(self):
         return self._get_property('access_token_params', {})
 
-    @cached_property
+    @property
     def access_token_method(self):
         return self._get_property('access_token_method', 'GET')
 
-    @cached_property
+    @property
     def content_type(self):
         return self._get_property('content_type', None)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,6 +110,69 @@ class TestOAuthRemoteApp(object):
         assert twitter.content_type is None
         assert 'realms' in twitter.request_token_params
 
+    def test_lazy_config_change(self):
+        """
+        Test propagation of config changes for 'lazy' loading.
+
+        Configuration values in Flask should be changeable.
+        """
+
+        # Setup app
+        oauth = OAuth()
+        twitter = oauth.remote_app(
+            'twitter',
+            app_key='twitter'
+        )
+
+        app = Flask(__name__)
+
+        # Initial configuration
+        app.config.update({
+            'twitter': dict(
+                base_url='https://api.twitter.com/1/',
+                request_token_params={'realms': 'email'},
+                consumer_key='twitter key',
+                consumer_secret='twitter secret',
+                request_token_url='request url',
+                access_token_url='token url',
+                authorize_url='auth url',
+            )
+        })
+        oauth.init_app(app)
+
+        # Make sure any eventual cache is populated
+        assert twitter.base_url == 'https://api.twitter.com/1/'
+        assert twitter.consumer_key == 'twitter key'
+        assert twitter.consumer_secret == 'twitter secret'
+        assert twitter.request_token_url == 'request url'
+        assert twitter.access_token_url == 'token url'
+        assert twitter.authorize_url == 'auth url'
+        assert twitter.content_type is None
+        assert 'realms' in twitter.request_token_params
+
+        # Updated configuration
+        app.config.update({
+            'twitter': dict(
+                base_url='https://api.twitter.com/2/',
+                request_token_params={'realms2': 'email'},
+                consumer_key='twitter key2',
+                consumer_secret='twitter secret2',
+                request_token_url='request url2',
+                access_token_url='token url2',
+                authorize_url='auth url2',
+            )
+        })
+
+        assert twitter.base_url == 'https://api.twitter.com/2/'
+        assert twitter.consumer_key == 'twitter key2'
+        assert twitter.consumer_secret == 'twitter secret2'
+        assert twitter.request_token_url == 'request url2'
+        assert twitter.access_token_url == 'token url2'
+        assert twitter.authorize_url == 'auth url2'
+        assert twitter.content_type is None
+        assert 'realms2' in twitter.request_token_params
+
+
     def test_lazy_load_with_plain_text_config(self):
         oauth = OAuth()
         twitter = oauth.remote_app('twitter', app_key='TWITTER')


### PR DESCRIPTION
In #23 a choice was made to load configuration from Flask rather than having to hardcode credentials, which was a _great_ decision. However, for some reason the choice was made to actually cache the configuration options.

This creates problems in certain test situations (our specific case was we needed to use the same remote with different URL's depending on whether doing integration in the browser tests or unit tests with a test client).

As the `_get_property` method seems to do nothing more than a `getattr` and/or dictionary lookups it should be quite fast already, in any case about as fast as `cached_property` which seems to use a dict. Hence, caching here (or actually memoizing) limits a particularly great feature of Flask (dynamic configuration) in return for very little else.

The pull req. contains a test demonstrating the fail case. You might also want to replace lazy by dynamic configuration (or deprecate hardcoded credentials in general and simply refer to the only proper method without adverbs).

In any case: thanks for your efforts in writing this and your attention reviewing this issue! :)
