### PR TITLE
Fix install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license='BSD',
     install_requires=[
         'Flask',
-        'oauthlib=>0.6.2',
+        'oauthlib>=0.6.2',
     ],
     tests_require=['nose', 'Flask-SQLAlchemy', 'mock'],
     test_suite='nose.collector',


### PR DESCRIPTION
Fix the follow error:

error in Flask-OAuthlib setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
