### PR TITLE
Make oauth object can handle requests with no user context

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -541,8 +541,6 @@ class OAuthRemoteApp(object):
     def get_request_token(self):
         assert self._tokengetter is not None, 'missing tokengetter'
         rv = self._tokengetter()
-        if rv is None:
-            raise OAuthException('No token available', type='token_missing')
         return rv
 
     def handle_oauth1_response(self):

--- a/tests/oauth1/client.py
+++ b/tests/oauth1/client.py
@@ -53,6 +53,13 @@ def create_client(app, oauth=None):
             return jsonify(resp)
         return str(resp)
 
+    @app.route('/about')
+    def about():
+        ret = oauth.get('about')
+        if ret.status not in (200, 201):
+            return abort(ret.status)
+        return ret.raw_data
+
     @app.route('/address')
     def address():
         ret = oauth.get('address/hangzhou')

--- a/tests/oauth1/server.py
+++ b/tests/oauth1/server.py
@@ -237,6 +237,10 @@ def create_server(app):
     def access_token():
         return {}
 
+    @app.route('/api/about')
+    def about_api():
+        return jsonify(info='flask-oauthlib test server')
+
     @app.route('/api/email')
     @oauth.require_oauth('email')
     def email_api():

--- a/tests/oauth1/test_oauth1.py
+++ b/tests/oauth1/test_oauth1.py
@@ -39,6 +39,10 @@ class OAuthSuite(BaseSuite):
 
 
 class TestWebAuth(OAuthSuite):
+    def test_request_with_no_user_context(self):
+        rv = self.client.get('/about')
+        assert 'flask-oauthlib' in u(rv.data)
+
     def test_full_flow(self):
         rv = self.client.get('/login')
         assert 'oauth_token' in rv.location


### PR DESCRIPTION
There is some requests which doesn't needs user token, like twitter's users/show.json [request](https://dev.twitter.com/docs/api/1.1/get/users/show).

This patch allows flask-oauthlib can handle such that requests.
