### PR TITLE
Fix issue with Werkzeug and weird query string urldecoding

### DIFF
--- a/flask_oauthlib/utils.py
+++ b/flask_oauthlib/utils.py
@@ -5,9 +5,22 @@ from flask import request, Response
 from oauthlib.common import to_unicode, bytes_type
 
 
+def _get_uri_from_request(request):
+    """
+    The uri returned from request.uri is not properly urlencoded
+    (sometimes it's partially urldecoded) This is a weird hack to get
+    werkzeug to return the proper urlencoded string uri
+    """
+    uri = request.base_url
+    if request.query_string:
+        uri += '?' + request.query_string.decode('utf-8')
+    return uri
+
+
 def extract_params():
     """Extract request params."""
-    uri = request.url
+
+    uri = _get_uri_from_request(request)
     http_method = request.method
     headers = dict(request.headers)
     if 'wsgi.input' in headers:

--- a/tests/oauth1/test_oauth1.py
+++ b/tests/oauth1/test_oauth1.py
@@ -95,12 +95,6 @@ class TestWebAuth(OAuthSuite):
         })
         assert 'error' in rv.location
 
-    def test_invalid_urlencoded(self):
-        rv = self.client.get('/oauth/request_token?query=tam%20q')
-        assert b'non+urlencoded' in rv.data
-        rv = self.client.get('/oauth/access_token?query=tam%20q')
-        assert b'non+urlencoded' in rv.data
-
 
 auth_header = (
     u'OAuth realm="%(realm)s",'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+import unittest
+import wsgiref.util
+from contextlib import contextmanager
+import mock
+import werkzeug.wrappers
+from flask_oauthlib.utils import extract_params
+from oauthlib.common import Request
+from flask import request
+
+
+@contextmanager
+def set_flask_request(wsgi_environ):
+    """
+    Test helper context manager that mocks the flask request global I didn't
+    need the whole request context just to test the functions in helpers and I
+    wanted to be able to set the raw WSGI environment
+    """
+    environ = {}
+    environ.update(wsgi_environ)
+    wsgiref.util.setup_testing_defaults(environ)
+    r = werkzeug.wrappers.Request(environ)
+
+    with mock.patch.dict(extract_params.__globals__, {'request': r}):
+        yield
+
+
+class UtilsTestSuite(unittest.TestCase):
+
+    def test_extract_params(self):
+        with set_flask_request({'QUERY_STRING': 'test=foo&foo=bar'}):
+            uri, http_method, body, headers = extract_params()
+            self.assertEquals(uri, 'http://127.0.0.1/?test=foo&foo=bar')
+            self.assertEquals(http_method, 'GET')
+            self.assertEquals(body, {})
+            self.assertEquals(headers, {'Host': '127.0.0.1'})
+
+    def test_extract_params_with_urlencoded_json(self):
+        wsgi_environ = {
+            'QUERY_STRING': 'state=%7B%22t%22%3A%22a%22%2C%22i%22%3A%22l%22%7D'
+        }
+        with set_flask_request(wsgi_environ):
+            uri, http_method, body, headers = extract_params()
+            # Request constructor will try to urldecode the querystring, make
+            # sure this doesn't fail.
+            Request(uri, http_method, body, headers)


### PR DESCRIPTION
Werkzeug's request object has a url method that returns a URL with a
partially-decoded querystring, causing some methods to fail in weird ways with
a message about urlencoding.  This patch fixes the problem for me.

I have also added a couple tests for the method in the utils model that
extracts the params from the request object since it was untested.  The second
test is the regresssion test that reproduces the bug.

I have also removed a test that I think is incorrect.  See my comments on the
commit here:

https://github.com/lepture/flask-oauthlib/commit/7102484e423686e9bc31b32688531b5fa4e827e9
