### PR TITLE
Fix wrong ordering of decorator arguments

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -644,7 +644,7 @@ class OAuthRemoteApp(object):
         @wraps(f)
         def decorated(*args, **kwargs):
             data = self.handle_response()
-            return f(*((data,) + args), **kwargs)
+            return f(*(args + (data,)), **kwargs)
         return decorated
 
 


### PR DESCRIPTION
If you are using `authorized_handler` decorator in class, it will override `self` argument. This fix solves this problem.
