### PR TITLE
Handle empty response from server

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -536,7 +536,7 @@ class OAuthRemoteApp(object):
                 type='token_generation_failed'
             )
         data = parse_response(resp, content)
-        if data is None:
+        if not data:
             raise OAuthException(
                 'Invalid token response from %s' % self.name,
                 type='token_generation_failed'


### PR DESCRIPTION
If the server returns an empty string, we should still raise an OAuthException.
