### PR TITLE
Updated error handling for Dropbox example

### DIFF
--- a/example/dropbox.py
+++ b/example/dropbox.py
@@ -44,7 +44,7 @@ def authorized():
     resp = dropbox.authorized_response()
     if resp is None:
         return 'Access denied: reason=%s error=%s' % (
-            request.args['error_reason'],
+            request.args['error'],
             request.args['error_description']
         )
     session['dropbox_token'] = (resp['access_token'], '')


### PR DESCRIPTION
According to https://www.dropbox.com/developers/core/docs#oa2-authorize there is no `error_reason` but rather an `error` code (per Section 4.1.2.1 of the OAuth 2.0 spec)
