### PR TITLE
Support for generating refresh tokens

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -131,11 +131,18 @@ class OAuth2Provider(object):
         if token_generator and not callable(token_generator):
             token_generator = import_string(token_generator)
 
+        refresh_token_generator = self.app.config.get(
+            'OAUTH2_PROVIDER_REFRESH_TOKEN_GENERATOR', None
+        )
+        if refresh_token_generator and not callable(refresh_token_generator):
+            refresh_token_generator = import_string(refresh_token_generator)
+
         if hasattr(self, '_validator'):
             return Server(
                 self._validator,
                 token_expires_in=expires_in,
                 token_generator=token_generator,
+                refresh_token_generator=refresh_token_generator,
             )
 
         if hasattr(self, '_clientgetter') and \
@@ -161,6 +168,7 @@ class OAuth2Provider(object):
                 validator,
                 token_expires_in=expires_in,
                 token_generator=token_generator,
+                refresh_token_generator=refresh_token_generator,
             )
         raise RuntimeError('application not bound to required getters')
 

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -389,7 +389,7 @@ class TestTokenGenerator(OAuthSuite):
 
     def create_oauth_provider(self, app):
 
-        def generator(request, refresh_token=False):
+        def generator(request):
             return 'foobar'
 
         app.config['OAUTH2_PROVIDER_TOKEN_GENERATOR'] = generator
@@ -401,6 +401,28 @@ class TestTokenGenerator(OAuthSuite):
         data = json.loads(u(rv.data))
         assert data['access_token'] == 'foobar'
         assert data['refresh_token'] == 'foobar'
+
+
+class TestRefreshTokenGenerator(OAuthSuite):
+
+    def create_oauth_provider(self, app):
+
+        def at_generator(request):
+            return 'foobar'
+
+        def rt_generator(request):
+            return 'abracadabra'
+
+        app.config['OAUTH2_PROVIDER_TOKEN_GENERATOR'] = at_generator
+        app.config['OAUTH2_PROVIDER_REFRESH_TOKEN_GENERATOR'] = rt_generator
+        return default_provider(app)
+
+    def test_get_access_token(self):
+        rv = self.client.post(authorize_url, data={'confirm': 'yes'})
+        rv = self.client.get(clean_url(rv.location))
+        data = json.loads(u(rv.data))
+        assert data['access_token'] == 'foobar'
+        assert data['refresh_token'] == 'abracadabra'
 
 
 class TestConfidentialClient(OAuthSuite):


### PR DESCRIPTION
Due to 5d0fc1182f6d9826764cc43ade99bc5e5a81c711 in oauthlib,
there are now separate generators for access tokens and refresh
tokens.

Adding a hook to also specify refresh token generator.

Test cases are added.
