### PR TITLE
Add appropriate headers when making POST request for access token

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -625,6 +625,7 @@ class OAuthRemoteApp(object):
             body = client.prepare_request_body(**remote_args)
             resp, content = self.http_request(
                 self.expand_url(self.access_token_url),
+                headers={'Content-Type': 'application/x-www-form-urlencoded'},
                 data=to_bytes(body, self.encoding),
                 method=self.access_token_method,
             )

--- a/tests/oauth2/client.py
+++ b/tests/oauth2/client.py
@@ -12,7 +12,7 @@ def create_client(app):
         request_token_params={'scope': 'email'},
         base_url='http://127.0.0.1:5000/api/',
         request_token_url=None,
-        access_token_method='GET',
+        access_token_method='POST',
         access_token_url='http://127.0.0.1:5000/oauth/token',
         authorize_url='http://127.0.0.1:5000/oauth/authorize'
     )

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -270,7 +270,7 @@ def create_server(app, oauth=None):
         confirm = request.form.get('confirm', 'no')
         return confirm == 'yes'
 
-    @app.route('/oauth/token')
+    @app.route('/oauth/token', methods=['POST', 'GET'])
     @oauth.token_handler
     def access_token():
         return {}


### PR DESCRIPTION
If these are not present, the server later does not parse request body into form data.