### PR TITLE
Make OAuth2 authorize_handler support HTTP HEAD the same way as GET

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -379,7 +379,7 @@ class OAuth2Provider(object):
             server = self.server
             uri, http_method, body, headers = extract_params()
 
-            if request.method == 'GET':
+            if request.method in ('GET', 'HEAD'):
                 redirect_uri = request.args.get('redirect_uri', None)
                 log.debug('Found redirect_uri %s.', redirect_uri)
                 try:

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from datetime import datetime, timedelta
-from flask import g, render_template, request, jsonify
+from flask import g, render_template, request, jsonify, make_response
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import relationship
 from flask_oauthlib.provider import OAuth2Provider
@@ -266,6 +266,13 @@ def create_server(app, oauth=None):
         if request.method == 'GET':
             # render a page for user to confirm the authorization
             return render_template('confirm.html')
+
+        if request.method == 'HEAD':
+            # if HEAD is supported properly, request parameters like
+            # client_id should be validated the same way as for 'GET'
+            response = make_response('', 200)
+            response.headers['X-Client-ID'] = kwargs.get('client_id')
+            return response
 
         confirm = request.form.get('confirm', 'no')
         return confirm == 'yes'

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -94,6 +94,10 @@ class TestWebAuth(OAuthSuite):
         assert 'code=' in rv.location
         assert 'state' in rv.location
 
+    def test_http_head_oauth_authorize_valid_url(self):
+        rv = self.client.head(authorize_url)
+        assert rv.headers['X-Client-ID'] == 'dev'
+
     def test_get_access_token(self):
         rv = self.client.post(authorize_url, data={'confirm': 'yes'})
         rv = self.client.get(clean_url(rv.location))


### PR DESCRIPTION
Fixes #172

This puts HEAD requests on the same code path as GET in `OAuth2Provider.authorize_handler()`. Effectively, this means that the request parameters will be parsed and validated the same way and passed onto the flask view function.

This behavior is prerequisite for those who want to follow RFC2616 sec 9.4:
> The HEAD method is identical to GET except that the server MUST NOT 
> return a message-body in the response.