### PR TITLE
Don't modify instance attributes when calling make_client with a token

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -11,6 +11,7 @@
 import logging
 import oauthlib.oauth1
 import oauthlib.oauth2
+from copy import copy
 from functools import wraps
 from oauthlib.common import to_unicode, PY3, add_params_to_uri
 from flask import request, redirect, json, session, current_app
@@ -339,7 +340,7 @@ class OAuthRemoteApp(object):
     def make_client(self, token=None):
         # request_token_url is for oauth1
         if self.request_token_url:
-            params = self.request_token_params or {}
+            params = copy(self.request_token_params) or {}
             if token and isinstance(token, (tuple, list)):
                 params["resource_owner_key"] = token[0]
                 params["resource_owner_secret"] = token[1]


### PR DESCRIPTION
When creating an OAuthRemoteApp object with a specific dict of "request_token_params", and afterwards calling make_client() with a specific token as an argument (for instance when calling any of the REST methods which in turn call request()), then "request_token_params" will be added the "resource_owner_key" and "resource_owner_secret" keys and values retrieved from the token passed.

Thus, if you want to call again the authorize() method, a new client will be created that will take as argument the "request_token_params" modified dict (see https://github.com/lepture/flask-oauthlib/blob/master/flask_oauthlib/client.py#L342, https://github.com/lepture/flask-oauthlib/blob/master/flask_oauthlib/client.py#L350).

This has happened to cause "OAuthException: Failed to generate request token" because of an Unauthorized response from the provider (in my particular case, Dropbox using OAuth 1.0).

This small PR solves this issue by doing a shallow copy of the "request_token_params" dict when calling make_client() with a token.