### PR TITLE
Change test for no content when parsing response

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -117,7 +117,7 @@ def parse_response(resp, content, strict=False, content_type=None):
     ct, options = parse_options_header(content_type)
 
     if ct in ('application/json', 'text/javascript'):
-        if content == '':
+        if not content:
             return {}
         return json.loads(content)
 


### PR DESCRIPTION
When parsing the response for a DELETE request to GitHub, I found I had
an empty byte-string instead of an empty string for my response data.
This caused OAuthlib to try and parse it with JSON, which will not work.
Changing the test to allow for any Falsey value will allow empty strings
or byte-strings to return an empty dict.