### PR TITLE
authenticate confidential client on grant_type == 'authentication_code'

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -583,11 +583,12 @@ class OAuth2RequestValidator(RequestValidator):
         .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
         """
 
-        client = self._clientgetter(request.client_id)
         if request.grant_type == 'password':
+            client = self._clientgetter(request.client_id)
             return (not client) or client.client_type == 'confidential' \
                     or client.client_secret
         elif request.grant_type == 'authorization_code':
+            client = self._clientgetter(request.client_id)
             return (not client) or client.client_type == 'confidential'
         return 'Authorization' in request.headers \
                 and request.grant_type == 'refresh_token'

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -583,14 +583,14 @@ class OAuth2RequestValidator(RequestValidator):
         .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
         """
 
+        client = self._clientgetter(request.client_id)
         if request.grant_type == 'password':
-            client = self._clientgetter(request.client_id)
-            return (not client) or client.client_type == 'confidential' or\
-                request.client_secret
-
-        auth_required = ('authorization_code', 'refresh_token')
-        return 'Authorization' in request.headers and\
-            request.grant_type in auth_required
+            return (not client) or client.client_type == 'confidential' \
+                    or client.client_secret
+        elif request.grant_type == 'authorization_code':
+            return (not client) or client.client_type == 'confidential'
+        return 'Authorization' in request.headers \
+                and request.grant_type == 'refresh_token'
 
     def authenticate_client(self, request, *args, **kwargs):
         """Authenticate itself in other means.


### PR DESCRIPTION
ref: http://tools.ietf.org/html/rfc6749#section-3.2.1

>  For example, the client makes the following HTTP request using TLS
>  (with extra line breaks for display purposes only):
>
>    POST /token HTTP/1.1
>    Host: server.example.com
>    Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
>    Content-Type: application/x-www-form-urlencoded
>
>    grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA
>    &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb
>
>  The authorization server MUST:
>
>   o  require client authentication for confidential clients or for any
>      client that was issued client credentials (or with other
>      authentication requirements),