### PR TITLE
do not check secret for non credential clients

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -644,11 +644,6 @@ class OAuth2RequestValidator(RequestValidator):
             log.debug('Authenticate failed, client not found.')
             return False
 
-        if request.grant_type == 'authorization_code' and \
-           client.client_secret != request.client_secret:
-            log.debug('Authenticate client failed, secret not match.')
-            return False
-
         # attach client on request for convenience
         request.client = client
         return True


### PR DESCRIPTION
If I understand correctly, `authenticate_client_id()`  authenticates a non-confidential client, but a non-confidential client can omit the secret on the `/token` request.

Also, if a client's secret has to be checked, it should be checked inside `authenticate_client()` after  `client_authentication_required()`. 

Regards