### PR TITLE
do not check client_type inside authenticate_client()

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -626,9 +626,6 @@ class OAuth2RequestValidator(RequestValidator):
             log.debug('Authenticate client failed, secret not match.')
             return False
 
-        if client.client_type != 'confidential':
-            log.debug('Authenticate client failed, not confidential.')
-            return False
         log.debug('Authenticate client success.')
         return True
 


### PR DESCRIPTION
as `client_authentication_required()` describes, a non confidential client might also enters `authenticate_client()`, but currently `authenticate_client()` blocks all non-confidential clients.

reference section 4.3.2:

>  The authorization server MUST:
>
>  o  require client authentication for confidential clients or for any
>      client that was issued client credentials (or with other
>      authentication requirements),

regards