### PR TITLE
Fix compliance_fixes not being correctly checked

### DIFF
--- a/flask_oauthlib/contrib/client/application.py
+++ b/flask_oauthlib/contrib/client/application.py
@@ -307,11 +307,12 @@ class OAuth2Application(BaseApplication):
 
         # patches session
         compliance_fixes = self.compliance_fixes
-        if compliance_fixes.startswith('.'):
-            compliance_fixes = \
-                'requests_oauthlib.compliance_fixes' + compliance_fixes
-        apply_fixes = import_string(compliance_fixes)
-        oauth = apply_fixes(oauth)
+        if compliance_fixes is not None:
+            if compliance_fixes.startswith('.'):
+                compliance_fixes = \
+                    'requests_oauthlib.compliance_fixes' + compliance_fixes
+            apply_fixes = import_string(compliance_fixes)
+            oauth = apply_fixes(oauth)
 
         return oauth
 


### PR DESCRIPTION
If no compliance_fixes were passed, the `compliance_fixes.startswith('.')` guard would always raise a NoneType exception, since the `compliance_fixes` property would evaluate to `None`.