### PR TITLE
Refactor the experiment OAuth 1.0a client.

### DIFF
--- a/flask_oauthlib/contrib/client/application.py
+++ b/flask_oauthlib/contrib/client/application.py
@@ -165,8 +165,8 @@ class OAuth1Application(BaseApplication):
                   object.
         """
         if isinstance(token, dict):
-            access_token = token['token']
-            access_token_secret = token['token_secret']
+            access_token = token['oauth_token']
+            access_token_secret = token['oauth_token_secret']
         else:
             access_token, access_token_secret = token
         return self.make_oauth_session(

--- a/flask_oauthlib/contrib/client/application.py
+++ b/flask_oauthlib/contrib/client/application.py
@@ -22,6 +22,7 @@ from werkzeug.utils import import_string
 from .descriptor import OAuthProperty, WebSessionData
 from .structure import OAuth1Response, OAuth2Response
 from .exceptions import AccessTokenNotFound
+from .signals import request_token_fetched
 
 
 __all__ = ['OAuth1Application', 'OAuth2Application']
@@ -179,9 +180,8 @@ class OAuth1Application(BaseApplication):
         oauth = self.make_oauth_session(callback_uri=callback_uri)
 
         # fetches request token
-        oauth.fetch_request_token(self.request_token_url)
-        # TODO send signal and pass token here
-        #      http://flask.pocoo.org/docs/0.10/signals/
+        token = oauth.fetch_request_token(self.request_token_url)
+        request_token_fetched.send(self, response=OAuth1Response(token))
         # TODO check oauth_callback_confirmed here
         #      http://tools.ietf.org/html/rfc5849#section-2.1
 

--- a/flask_oauthlib/contrib/client/signals.py
+++ b/flask_oauthlib/contrib/client/signals.py
@@ -1,0 +1,6 @@
+from flask.signals import Namespace
+
+__all__ = ['request_token_fetched']
+
+_signals = Namespace()
+request_token_fetched = _signals.signal('request-token-fetched')

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'Flask',
         'oauthlib>=0.6.2',
-        'requests-oauthlib>=0.4.1',
+        'requests-oauthlib>=0.5.0',
     ],
     tests_require=['nose', 'Flask-SQLAlchemy', 'mock'],
     test_suite='nose.collector',


### PR DESCRIPTION
- Using querystring passed `oauth_token` instead of the session stashed one, because storing request token and request token secret in cookie is nonstandard and insecure.
- Fixing the wrong dictionary schema accepted by `make_client` method.
- Adding `request_token_fetched` signal to allow people inspect the request token.

@lepture plz review, thx.