### PR TITLE
Remove incorrect handling of scope

### DIFF
--- a/flask_oauthlib/contrib/client/application.py
+++ b/flask_oauthlib/contrib/client/application.py
@@ -273,10 +273,7 @@ class OAuth2Application(BaseApplication):
         return OAuth2Response(token)
 
     def make_oauth_session(self, **kwargs):
-        # joins scope into unicode
         kwargs.setdefault('scope', self.scope)
-        if kwargs['scope']:
-            kwargs['scope'] = u','.join(kwargs['scope'])
 
         # configures automatic token refresh if possible
         if self.refresh_token_url:


### PR DESCRIPTION
The contrib client joins a list of scope with a comma which is wrong.
[RFC6749 section 3.3](https://tools.ietf.org/html/rfc6749#section-3.3) specifies the scopes must be
> expressed as a list of space-delimited, case-sensitive strings.

Processing the scope at this point is also not necessary as the scope
are passed to [requests-oauthlib](https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py#L120-L124) and then [oauthlib](https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/parameters.py#L75-L76) which can [handle a
Python list](https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/utils.py#L23-L32) just fine.

This is also more consistent with the OAuth2 client which [passes the
scope directly to oauthlib](https://github.com/lepture/flask-oauthlib/blob/master/flask_oauthlib/client.py#L523-L529) as well.