### PR TITLE
Implement 0-legged oauth1

### DIFF
--- a/example/facebook.py
+++ b/example/facebook.py
@@ -19,6 +19,7 @@ facebook = oauth.remote_app(
     base_url='https://graph.facebook.com',
     request_token_url=None,
     access_token_url='/oauth/access_token',
+    access_token_method='GET',
     authorize_url='https://www.facebook.com/dialog/oauth'
 )
 

--- a/flask_oauthlib/contrib/client/application.py
+++ b/flask_oauthlib/contrib/client/application.py
@@ -307,11 +307,12 @@ class OAuth2Application(BaseApplication):
 
         # patches session
         compliance_fixes = self.compliance_fixes
-        if compliance_fixes.startswith('.'):
-            compliance_fixes = \
-                'requests_oauthlib.compliance_fixes' + compliance_fixes
-        apply_fixes = import_string(compliance_fixes)
-        oauth = apply_fixes(oauth)
+        if compliance_fixes is not None:
+            if compliance_fixes.startswith('.'):
+                compliance_fixes = \
+                    'requests_oauthlib.compliance_fixes' + compliance_fixes
+            apply_fixes = import_string(compliance_fixes)
+            oauth = apply_fixes(oauth)
 
         return oauth
 


### PR DESCRIPTION
After several iterations, this is the cleanest implementation I've found to add support for oauth1 requests that do not include an access token. There are many cases when you an endpoint does not contain any user specific data, but it should still be restricted to known clients and not made public.

I've used this extensively in production environments and updated the documentation, but haven't run the sample code I threw into there. This does introduce one more lint error (for a line that's too long by 1 character) and adds one more untested line of code to the coverage report since I didn't add any tests for this.

The only thing to note is that the realms parameter is only applicable to access tokens. So, when require_user is false, the realms defined on the client is not compared to the realms defined in the require_oauth decorator. This should probably be explained in the docs or code should be added to validate the client has access to the specified realms. I don't use realms heavily in my applications, so I'm not sure what the desired behavior is.