### PR TITLE
Fix expires_in not returning to client in example

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -310,7 +310,7 @@ and accessing resource flow. They are implemented with decorators as follows::
         for t in toks:
             db.session.delete(t)
 
-        expires_in = token.pop('expires_in')
+        expires_in = token.get('expires_in')
         expires = datetime.utcnow() + timedelta(seconds=expires_in)
 
         tok = Token(


### PR DESCRIPTION
When popping the "expires_in" from client this causes the client to not recieve that information in the response, when it was likely intended that they should.

This caused me like 30 minutes of digging until I realized it was my code which I copied from the examples causing the problem... Figured this wasn't intended.