### PR TITLE
catch Exception in oauth2.py

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -18,7 +18,7 @@ from werkzeug import cached_property
 from werkzeug.utils import import_string
 from oauthlib import oauth2
 from oauthlib.oauth2 import RequestValidator, Server
-from oauthlib.common import to_unicode
+from oauthlib.common import to_unicode, add_params_to_uri
 from ..utils import extract_params, decode_base64, create_response
 
 __all__ = ('OAuth2Provider', 'OAuth2RequestValidator')
@@ -394,6 +394,11 @@ class OAuth2Provider(object):
                 except oauth2.OAuth2Error as e:
                     log.debug('OAuth2Error: %r', e)
                     return redirect(e.in_uri(redirect_uri))
+                except Exception as e:
+                    log.warning('Exception caught while processing request, %s.' % e)
+                    return redirect(add_params_to_uri(
+                        self.error_uri, {'error': str(e) }
+                    ))
 
             else:
                 redirect_uri = request.values.get(
@@ -408,6 +413,12 @@ class OAuth2Provider(object):
             except oauth2.OAuth2Error as e:
                 log.debug('OAuth2Error: %r', e)
                 return redirect(e.in_uri(redirect_uri))
+            except Exception as e:
+                log.warning('Exception caught while processing request, %s.' % e)
+                return redirect(add_params_to_uri(
+                    self.error_uri, {'error': str(e) }
+                ))
+
 
             if not isinstance(rv, bool):
                 # if is a response or redirect
@@ -447,6 +458,12 @@ class OAuth2Provider(object):
         except oauth2.OAuth2Error as e:
             log.debug('OAuth2Error: %r', e)
             return redirect(e.in_uri(redirect_uri or self.error_uri))
+        except Exception as e:
+            log.warning('Exception caught while processing request, %s.' % e)
+            return redirect(add_params_to_uri(
+                self.error_uri, {'error': str(e) }
+            ))
+
 
     def verify_request(self, scopes):
         """Verify current request, get the oauth data.

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -177,16 +177,6 @@ class TestWebAuth(OAuthSuite):
         assert b'error' in rv.data
         assert b'invalid_scope' in rv.data
 
-    def test_invalid_redirect_uri(self):
-        authorize_url = (
-            '/oauth/authorize?response_type=code&client_id=dev'
-            '&redirect_uri=http://localhost:8000/authorized'
-            '&scope=invalid'
-        )
-        rv = self.client.get(authorize_url)
-        assert 'error=' in rv.location
-        assert 'trying+to+decode+a+non+urlencoded+string' in rv.location
-
 
 class TestWebAuthCached(TestWebAuth):
 

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -177,6 +177,16 @@ class TestWebAuth(OAuthSuite):
         assert b'error' in rv.data
         assert b'invalid_scope' in rv.data
 
+    def test_invalid_redirect_uri(self):
+        authorize_url = (
+            '/oauth/authorize?response_type=code&client_id=dev'
+            '&redirect_uri=http://localhost:8000/authorized'
+            '&scope=invalid'
+        )
+        rv = self.client.get(authorize_url)
+        assert 'error=' in rv.location
+        assert 'trying+to+decode+a+non+urlencoded+string' in rv.location
+
 
 class TestWebAuthCached(TestWebAuth):
 

--- a/tests/test_oauth2/test_code.py
+++ b/tests/test_oauth2/test_code.py
@@ -70,6 +70,16 @@ class TestDefaultProvider(TestCase):
         assert b'invalid_client' not in rv.data
         assert rv.status_code == 401
 
+    def test_invalid_redirect_uri(self):
+        authorize_url = (
+            '/oauth/authorize?response_type=code&client_id=dev'
+            '&redirect_uri=http://localhost:8000/authorized'
+            '&scope=invalid'
+        )
+        rv = self.client.get(authorize_url)
+        assert 'error=' in rv.location
+        assert 'trying+to+decode+a+non+urlencoded+string' in rv.location
+
     def test_get_token(self):
         expires = datetime.utcnow() + timedelta(seconds=100)
         grant = Grant(

--- a/tests/test_oauth2/test_code.py
+++ b/tests/test_oauth2/test_code.py
@@ -50,6 +50,10 @@ class TestDefaultProvider(TestCase):
         rv = self.client.post(url, data={'confirm': 'yes'})
         assert 'code' in rv.location
 
+        url = self.authorize_url + '&scope='
+        rv = self.client.post(url, data={'confirm': 'yes'})
+        assert 'error=Scopes+must+be+set' in rv.location
+
     def test_invalid_token(self):
         rv = self.client.get('/oauth/token')
         assert b'unsupported_grant_type' in rv.data


### PR DESCRIPTION
currently we'd get a 500 Internal Error if we pass an invalid `redirect_uri` to the /authorized view. Here's the backtrace, we can find that there's a ValueError from oauthlib escaped without any catch.

```
217   File "/data/apps/clouda_oauth2/parts/flask-oauthlib/flask_oauthlib/provider/oauth2.py", line 387, in decorated
218     uri, http_method, body, headers
219   File "/data/apps/clouda_oauth2/eggs/oauthlib-0.7.2-py2.7.egg/oauthlib/oauth2/rfc6749/endpoints/base.py", line 64, in wrapper
220     return f(endpoint, uri, *args, **kwargs)
221   File "/data/apps/clouda_oauth2/eggs/oauthlib-0.7.2-py2.7.egg/oauthlib/oauth2/rfc6749/endpoints/authorization.py", line 110, in validate_authorization_request
222     uri, http_method=http_method, body=body, headers=headers)
223   File "/data/apps/clouda_oauth2/eggs/oauthlib-0.7.2-py2.7.egg/oauthlib/common.py", line 395, in __init__
224     self._params.update(dict(urldecode(self.uri_query)))
225   File "/data/apps/clouda_oauth2/eggs/oauthlib-0.7.2-py2.7.egg/oauthlib/common.py", line 129, in urldecode
226     raise ValueError(error % (set(query) - urlencoded, query))
227 ValueError: Error trying to decode a non urlencoded string. Found invalid characters: set([u':', u'/']) in the string: 'response_type=code&client_id=oauthtestapp&redirect_uri=http://localhost:9000/callback&scope=all'. Please ensure the request/response body is x-www-f    orm-urlencoded.
```

this PR adds `except Exception` in oauth2.py to catch the uncaught exceptions from oauthlib.

