### PR TITLE
Be more careful about attribute access and specify oauthlib version

### DIFF
--- a/flask_oauthlib/provider/oauth1.py
+++ b/flask_oauthlib/provider/oauth1.py
@@ -635,7 +635,7 @@ class OAuth1RequestValidator(RequestValidator):
         The client object must has ``client_secret`` attribute.
         """
         log.debug('Get client secret of %r', client_key)
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
         if request.client:
             return request.client.client_secret
@@ -648,7 +648,9 @@ class OAuth1RequestValidator(RequestValidator):
         """
         log.debug('Get request token secret of %r for %r',
                   token, client_key)
-        tok = request.request_token or self._grantgetter(token=token)
+
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         if tok and tok.client_key == client_key:
             request.request_token = tok
             return tok.secret
@@ -674,7 +676,7 @@ class OAuth1RequestValidator(RequestValidator):
         """Default realms of the client."""
         log.debug('Get realms for %r', client_key)
 
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
 
         client = request.client
@@ -685,7 +687,8 @@ class OAuth1RequestValidator(RequestValidator):
     def get_realms(self, token, request):
         """Realms for this request token."""
         log.debug('Get realms of %r', token)
-        tok = request.request_token or self._grantgetter(token=token)
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         if not tok:
             return []
         request.request_token = tok
@@ -696,12 +699,13 @@ class OAuth1RequestValidator(RequestValidator):
     def get_redirect_uri(self, token, request):
         """Redirect uri for this request token."""
         log.debug('Get redirect uri of %r', token)
-        tok = request.request_token or self._grantgetter(token=token)
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         return tok.redirect_uri
 
     def get_rsa_key(self, client_key, request):
         """Retrieves a previously stored client provided RSA key."""
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
         if hasattr(request.client, 'rsa_key'):
             return request.client.rsa_key
@@ -714,7 +718,7 @@ class OAuth1RequestValidator(RequestValidator):
     def validate_client_key(self, client_key, request):
         """Validates that supplied client key."""
         log.debug('Validate client key for %r', client_key)
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
         if request.client:
             return True
@@ -724,7 +728,8 @@ class OAuth1RequestValidator(RequestValidator):
         """Validates request token is available for client."""
         log.debug('Validate request token %r for %r',
                   token, client_key)
-        tok = request.request_token or self._grantgetter(token=token)
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         if tok and tok.client_key == client_key:
             request.request_token = tok
             return True
@@ -765,7 +770,7 @@ class OAuth1RequestValidator(RequestValidator):
     def validate_redirect_uri(self, client_key, redirect_uri, request):
         """Validate if the redirect_uri is allowed by the client."""
         log.debug('Validate redirect_uri %r for %r', redirect_uri, client_key)
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
         if not request.client:
             return False
@@ -776,7 +781,7 @@ class OAuth1RequestValidator(RequestValidator):
 
     def validate_requested_realms(self, client_key, realms, request):
         log.debug('Validate requested realms %r for %r', realms, client_key)
-        if not hasattr(request, 'client') or not getattr(request, 'client'):
+        if not getattr(request, 'client', None):
             request.client = self._clientgetter(client_key=client_key)
 
         client = request.client
@@ -819,7 +824,8 @@ class OAuth1RequestValidator(RequestValidator):
     def verify_request_token(self, token, request):
         """Verify if the request token is existed."""
         log.debug('Verify request token %r', token)
-        tok = request.request_token or self._grantgetter(token=token)
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         if tok:
             request.request_token = tok
             return True
@@ -828,7 +834,8 @@ class OAuth1RequestValidator(RequestValidator):
     def verify_realms(self, token, realms, request):
         """Verify if the realms match the requested realms."""
         log.debug('Verify realms %r', realms)
-        tok = request.request_token or self._grantgetter(token=token)
+        tok = (getattr(request, 'request_token', None)
+               or self._grantgetter(token=token))
         if not tok:
             return False
 

--- a/flask_oauthlib/provider/oauth1.py
+++ b/flask_oauthlib/provider/oauth1.py
@@ -635,7 +635,7 @@ class OAuth1RequestValidator(RequestValidator):
         The client object must has ``client_secret`` attribute.
         """
         log.debug('Get client secret of %r', client_key)
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
         if request.client:
             return request.client.client_secret
@@ -674,7 +674,7 @@ class OAuth1RequestValidator(RequestValidator):
         """Default realms of the client."""
         log.debug('Get realms for %r', client_key)
 
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
 
         client = request.client
@@ -701,7 +701,7 @@ class OAuth1RequestValidator(RequestValidator):
 
     def get_rsa_key(self, client_key, request):
         """Retrieves a previously stored client provided RSA key."""
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
         if hasattr(request.client, 'rsa_key'):
             return request.client.rsa_key
@@ -714,7 +714,7 @@ class OAuth1RequestValidator(RequestValidator):
     def validate_client_key(self, client_key, request):
         """Validates that supplied client key."""
         log.debug('Validate client key for %r', client_key)
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
         if request.client:
             return True
@@ -765,7 +765,7 @@ class OAuth1RequestValidator(RequestValidator):
     def validate_redirect_uri(self, client_key, redirect_uri, request):
         """Validate if the redirect_uri is allowed by the client."""
         log.debug('Validate redirect_uri %r for %r', redirect_uri, client_key)
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
         if not request.client:
             return False
@@ -776,7 +776,7 @@ class OAuth1RequestValidator(RequestValidator):
 
     def validate_requested_realms(self, client_key, realms, request):
         log.debug('Validate requested realms %r for %r', realms, client_key)
-        if not request.client:
+        if not hasattr(request, 'client') or not getattr(request, 'client'):
             request.client = self._clientgetter(client_key=client_key)
 
         client = request.client

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -597,11 +597,8 @@ class OAuth2RequestValidator(RequestValidator):
                 log.debug('Authenticate client failed with exception: %r', e)
                 return False
         else:
-            client_id = client_secret = None
-            if hasattr(request, 'client_id'):
-                client_id = request.client_id
-            if hasattr(request, 'client_secret'):
-                client_secret = request.client_secret
+            client_id = getattr(request, 'client_id', None)
+            client_secret = getattr(request, 'client_secret', None)
 
         client = self._clientgetter(client_id)
         if not client:
@@ -925,7 +922,9 @@ class OAuth2RequestValidator(RequestValidator):
             if not tok:
                 tok = self._tokengetter(refresh_token=token)
 
-        if tok and tok.client_id == request.client.client_id:
+        if tok and tok.client_id == getattr(request.client,
+                                            'client_id',
+                                            None):
             request.client_id = tok.client_id
             request.user = tok.user
             tok.delete()

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -577,12 +577,15 @@ class OAuth2RequestValidator(RequestValidator):
         Authorization Code Grant: see `Section 4.1.3`_.
         Refresh Token Grant: see `Section 6`_.
 
+        Also returns true for null grant_types, which can be revocation
+        requests.
+
         .. _`Section 4.3.2`: http://tools.ietf.org/html/rfc6749#section-4.3.2
         .. _`Section 4.1.3`: http://tools.ietf.org/html/rfc6749#section-4.1.3
         .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
         """
         grant_types = ('password', 'authorization_code', 'refresh_token')
-        return request.grant_type in grant_types
+        return request.grant_type in grant_types or request.grant_type is None
 
     def authenticate_client(self, request, *args, **kwargs):
         auth = request.headers.get('Authorization', None)

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -597,8 +597,11 @@ class OAuth2RequestValidator(RequestValidator):
                 log.debug('Authenticate client failed with exception: %r', e)
                 return False
         else:
-            client_id = request.client_id
-            client_secret = request.client_secret
+            client_id = client_secret = None
+            if hasattr(request, 'client_id'):
+                client_id = request.client_id
+            if hasattr(request, 'client_secret'):
+                client_secret = request.client_secret
 
         client = self._clientgetter(client_id)
         if not client:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
 Mock
-oauthlib
+oauthlib~=1.0
 requests-oauthlib
 Flask-SQLAlchemy

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -69,7 +69,7 @@ class TestWebAuth(OAuthSuite):
 
     def test_oauth_authorize_invalid_url(self):
         rv = self.client.get('/oauth/authorize')
-        assert 'invalid_client_id' in rv.location
+        assert 'Missing+client_id' in rv.location
 
     def test_oauth_authorize_valid_url(self):
         rv = self.client.get(authorize_url)

--- a/tests/test_oauth2/test_code.py
+++ b/tests/test_oauth2/test_code.py
@@ -29,10 +29,10 @@ class TestDefaultProvider(TestCase):
 
     def test_get_authorize(self):
         rv = self.client.get('/oauth/authorize')
-        assert 'invalid_client_id' in rv.location
+        assert 'Missing+client_id' in rv.location
 
         rv = self.client.get('/oauth/authorize?client_id=no')
-        assert 'invalid_client_id' in rv.location
+        assert 'Invalid+client_id' in rv.location
 
         url = '/oauth/authorize?client_id=%s' % self.oauth_client.client_id
         rv = self.client.get(url)


### PR DESCRIPTION
A recent commit to oauthlib added an AttributeError when unspecified attributes are retrieved from a Request: https://github.com/idan/oauthlib/commit/539558a02edbadb8d6ef690fb0beb2510a5eeb17

Since Flask-OAuthlib depends on only the latest version of oauthlib, a recent fresh deploy of our codebase started failing with an AttributeError (we don't pass a client_secret in the url since we're using XHR from a browser). The issue was caught by Flask-OAuthlib's tests, too.

This patch fixes this error by checking `hasattr` before accessing `client` (in oauth2), `client_secret` and `client_id` from the request object, and also specifies an oauth version in `requirements.txt` (using [compatible release syntax](https://www.python.org/dev/peps/pep-0440/#compatible-release), which should be current for a while yet).