### PR TITLE
Fix Bearer token revokation

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -588,14 +588,19 @@ class OAuth2RequestValidator(RequestValidator):
         auth = request.headers.get('Authorization', None)
         log.debug('Authenticate client %r', auth)
         if auth:
-            try:
-                _, s = auth.split(' ')
-                client_id, client_secret = decode_base64(s).split(':')
-                client_id = to_unicode(client_id, 'utf-8')
-                client_secret = to_unicode(client_secret, 'utf-8')
-            except Exception as e:
-                log.debug('Authenticate client failed with exception: %r', e)
-                return False
+            token_type, t = auth.split(' ')
+            if token_type == 'Bearer':
+                tok = self._tokengetter(access_token=t)
+                client_id = tok.client.client_id
+                client_secret = tok.client.client_secret
+            else:
+                try:
+                    client_id, client_secret = decode_base64(t).split(':')
+                    client_id = to_unicode(client_id, 'utf-8')
+                    client_secret = to_unicode(client_secret, 'utf-8')
+                except Exception as e:
+                    log.debug('Authenticate client failed with exception: %r', e)
+                    return False
         else:
             client_id = request.client_id
             client_secret = request.client_secret

--- a/tests/test_oauth2/test_password.py
+++ b/tests/test_oauth2/test_password.py
@@ -68,7 +68,7 @@ class TestDefaultProvider(TestCase):
             'grant_type': 'password',
             'username': 'foo',
             'password': 'right',
-        }, headers={'Authorization': 'Basic %s' % auth})
+        }, headers={'Authorization': 'Basic %s' % (auth)})
         assert b'access_token' in rv.data
 
     def test_disallow_grant_type(self):


### PR DESCRIPTION
It didn't work with Bearer token because Bearer tokens are not
encoded in base64.

Closes #233 
