### PR TITLE
Prevent public clients from authenticating with client_credentials

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,5 @@
 - Mackenzie Blake Thompson https://github.com/flippmoke
 - Ib Lundgren https://github.com/ib-lundgren
 - Jiangge Zhang https://github.com/tonyseek
+- Sami Hiltunen https://github.com/samihiltunen
 - Stian Prestholdt https://github.com/stianpr

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -586,12 +586,12 @@ class OAuth2RequestValidator(RequestValidator):
         if request.grant_type == 'password':
             client = self._clientgetter(request.client_id)
             return (not client) or client.client_type == 'confidential' \
-                    or client.client_secret
+                or client.client_secret
         elif request.grant_type == 'authorization_code':
             client = self._clientgetter(request.client_id)
             return (not client) or client.client_type == 'confidential'
         return 'Authorization' in request.headers \
-                and request.grant_type == 'refresh_token'
+            and request.grant_type == 'refresh_token'
 
     def authenticate_client(self, request, *args, **kwargs):
         """Authenticate itself in other means.
@@ -621,6 +621,11 @@ class OAuth2RequestValidator(RequestValidator):
             return False
 
         request.client = client
+
+        if request.grant_type == 'client_credentials' and \
+           client.client_type != 'confidential':
+                log.debug('Authenticate client failed, not confidential.')
+                return False
 
         if client.client_secret != client_secret:
             log.debug('Authenticate client failed, secret not match.')
@@ -839,7 +844,7 @@ class OAuth2RequestValidator(RequestValidator):
             'authorization_code', 'password',
             'client_credentials', 'refresh_token',
         )
-        
+
         # Grant type is allowed if it is part of the 'allowed_grant_types'
         # of the selected client or if it is one of the default grant types
         if hasattr(client, 'allowed_grant_types'):


### PR DESCRIPTION
Commit e82c0b4509304e458f431ca1ec355d6c1972cfb1 allows public clients to authenticate using client credentials. The OAuth2 specification says that this should not be allowed  (http://tools.ietf.org/html/rfc6749#page-41). I've modified the code removed in the earlier commit so it addresses the issue mentioned on the commit message and still blocks public clients from authenticating with client credentials.

When will a version containing this fix be released on PyPI?