### PR TITLE
Added endpoint invocation for revoke handler

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -521,6 +521,7 @@ class OAuth2Provider(object):
             uri, http_method, body, headers = extract_params()
             ret = server.create_revocation_response(
                 uri, headers=headers, body=body, http_method=http_method)
+            f(*args, **kwargs)
             return create_response(*ret)
         return decorated
 


### PR DESCRIPTION
We are using Flask-OAuthlib as an OAuth2 provided in our infrastructure. To reduce the weight of hitting our authorization service, we have added caching for user information in other service. However, when a user logs out/revokes their token, we would like to remove the cached information immediately.

To perform this cache bust, we would like to add logic into the `revoke_handler` endpoint (e.g. send a webhook to other services). Unfortunately, the current implementation doesn't invoke the `revoke_handler` contents at all. This PR remedies that.

In this PR:

- Added endpoint invocation for revoke handler