### PR TITLE
[Fix Bug] When library call authenticate_client but client's secret key is null that can cause the program raise a 500 Internal Server Error.

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -622,9 +622,12 @@ class OAuth2RequestValidator(RequestValidator):
 
         request.client = client
 
-        if client.client_secret != client_secret:
-            log.debug('Authenticate client failed, secret not match.')
-            return False
+        # http://tools.ietf.org/html/rfc6749#section-2
+        # The client MAY omit the parameter if the client secret is an empty string.
+        if hasattr(client, 'client_secret'):
+            if client.client_secret != client_secret:
+                log.debug('Authenticate client failed, secret not match.')
+                return False
 
         log.debug('Authenticate client success.')
         return True

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -624,8 +624,7 @@ class OAuth2RequestValidator(RequestValidator):
 
         # http://tools.ietf.org/html/rfc6749#section-2
         # The client MAY omit the parameter if the client secret is an empty string.
-        if hasattr(client, 'client_secret'):
-            if client.client_secret != client_secret:
+        if hasattr(client, 'client_secret') and client.client_secret != client_secret:
                 log.debug('Authenticate client failed, secret not match.')
                 return False
 


### PR DESCRIPTION
The client MAY omit the parameter if the client secret is an empty string. So it need to check the client_secret.