### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Additional Notes
 
 We keep documentation at `flask-oauthlib@readthedocs`_.
 
-.. _`flask-oauthlib@readthedocs`: https://flask-oauthlib.readthedocs.org
+.. _`flask-oauthlib@readthedocs`: https://flask-oauthlib.readthedocs.io
 
 If you are only interested in the client part, you can find some examples
 in the ``example`` directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.