### PR TITLE
show original error message 

### DIFF
--- a/example/twitter.py
+++ b/example/twitter.py
@@ -59,8 +59,12 @@ def tweet():
     resp = twitter.post('statuses/update.json', data={
         'status': status
     })
+
     if resp.status == 403:
-        flash('Your tweet was too long.')
+        flash("Error: #%d, %s " % (
+            resp.data.get('errors')[0].get('code'),
+            resp.data.get('errors')[0].get('message'))
+        )
     elif resp.status == 401:
         flash('Authorization error with Twitter.')
     else:


### PR DESCRIPTION
this pull request related to #276, instead of showing redacted message, it will print out original error message when HTTP 403 found.