### PR TITLE
Improve handling of github authorization error

### DIFF
--- a/example/github.py
+++ b/example/github.py
@@ -42,10 +42,11 @@ def logout():
 @app.route('/login/authorized')
 def authorized():
     resp = github.authorized_response()
-    if resp is None:
-        return 'Access denied: reason=%s error=%s' % (
+    if resp is None or resp.get('access_token') is None:
+        return 'Access denied: reason=%s error=%s resp=%s' % (
             request.args['error'],
-            request.args['error_description']
+            request.args['error_description'],
+            resp
         )
     session['github_token'] = (resp['access_token'], '')
     me = github.get('user')


### PR DESCRIPTION
First, thanks for the library!

I don't see a way for the `authorized_response` method to ever return `None`. Regardless, it seems possible that the response could be something other than `None` like an `OAuthException` so checking for only `None` seem insufficient.

This change fixes the situation where `authorized_response` returns something other than `None` but there is no `access_token` in the response.  I've been seeing this fail on my app with a `KeyError` on line 51.  So, I'm currently losing the real error from github which could explain *why* the `access_token` is missing.

Am I missing something?