### PR TITLE
Updated OAuth2 example links in oauth2.rst

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -490,6 +490,8 @@ The ``request`` has an additional property ``oauth``, it contains at least:
 Example for OAuth 2
 -------------------
 
-Here is an example of OAuth 2 server: https://github.com/lepture/example-oauth2-server
+An examplary server (and client) can be found in the tests folder: https://github.com/lepture/flask-oauthlib/tree/master/tests/oauth2
 
-Also read this article http://lepture.com/en/2013/create-oauth-server.
+Other helpful resources include: 
+ - Another example of an OAuth 2 server: https://github.com/lepture/example-oauth2-server
+ - An article on how to create an OAuth server: http://lepture.com/en/2013/create-oauth-server.


### PR DESCRIPTION
Adds a link to the github test folder for the OAuth2 server example. The information there appears to be a lot more up to date than those in the mentioned resources.