### PR TITLE
Handle HTTP Basic Auth for client's access to token endpoint

### DIFF
--- a/flask_oauthlib/utils.py
+++ b/flask_oauthlib/utils.py
@@ -27,6 +27,11 @@ def extract_params():
         del headers['wsgi.input']
     if 'wsgi.errors' in headers:
         del headers['wsgi.errors']
+    # Werkzeug, and subsequently Flask provide a safe Authorization header
+    # parsing, so we just replace the Authorization header with the extraced
+    # info if it was successfully parsed.
+    if request.authorization:
+        headers['Authorization'] = request.authorization
 
     body = request.form.to_dict()
     return uri, http_method, body, headers

--- a/tests/_base.py
+++ b/tests/_base.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import base64
 import os
 import sys
 import tempfile
@@ -89,6 +90,10 @@ def to_bytes(text):
     if isinstance(text, string_type):
         text = text.encode('utf-8')
     return text
+
+
+def to_base64(text):
+    return to_unicode(base64.b64encode(to_bytes(text)))
 
 
 def clean_url(location):

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 import json
-import base64
 from flask import Flask
 from mock import MagicMock
 from .server import (
@@ -13,8 +12,7 @@ from .server import (
     Token
 )
 from .client import create_client
-from .._base import BaseSuite, clean_url
-from .._base import to_bytes as b
+from .._base import BaseSuite, clean_url, to_base64
 from .._base import to_unicode as u
 
 
@@ -51,11 +49,7 @@ authorize_url = (
 )
 
 
-def _base64(text):
-    return u(base64.b64encode(b(text)))
-
-
-auth_code = _base64('confidential:confidential')
+auth_code = to_base64('confidential:confidential')
 
 
 class TestWebAuth(OAuthSuite):
@@ -313,7 +307,7 @@ class TestCredentialAuth(OAuthSuite):
         assert b'invalid_client' in rv.data
 
     def test_no_client(self):
-        auth_code = _base64('none:confidential')
+        auth_code = to_base64('none:confidential')
         url = ('/oauth/token?grant_type=client_credentials'
                '&scope=email+address')
         rv = self.client.get(url, headers={
@@ -322,7 +316,7 @@ class TestCredentialAuth(OAuthSuite):
         assert b'invalid_client' in rv.data
 
     def test_wrong_secret_client(self):
-        auth_code = _base64('confidential:wrong')
+        auth_code = to_base64('confidential:wrong')
         url = ('/oauth/token?grant_type=client_credentials'
                '&scope=email+address')
         rv = self.client.get(url, headers={

--- a/tests/test_oauth2/test_client_credential.py
+++ b/tests/test_oauth2/test_client_credential.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from .._base import to_base64
 from .base import TestCase
 from .base import create_server, sqlalchemy_provider, cache_provider
 from .base import db, Client, User
@@ -28,6 +29,18 @@ class TestDefaultProvider(TestCase):
             'grant_type': 'client_credentials',
             'client_id': self.oauth_client.client_id,
             'client_secret': self.oauth_client.client_secret,
+        })
+        assert b'access_token' in rv.data
+
+        rv = self.client.post('/oauth/token', data={
+            'grant_type': 'client_credentials'
+        }, headers={
+            'authorization': 'Basic ' + to_base64(
+                    '%s:%s' % (
+                        self.oauth_client.client_id,
+                        self.oauth_client.client_secret
+                    )
+                )
         })
         assert b'access_token' in rv.data
 

--- a/tests/test_oauth2/test_refresh.py
+++ b/tests/test_oauth2/test_refresh.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+import json
+from .._base import to_base64, to_unicode as u
 from .base import TestCase
 from .base import create_server, sqlalchemy_provider, cache_provider
 from .base import db, Client, User, Token
@@ -79,6 +81,20 @@ class TestDefaultProvider(TestCase):
             'refresh_token': token.refresh_token,
             'client_id': self.confidential_client.client_id,
             'client_secret': self.confidential_client.client_secret,
+        })
+        assert b'access_token' in rv.data
+
+        token.refresh_token = json.loads(u(rv.data))['refresh_token']
+        rv = self.client.post('/oauth/token', data={
+            'grant_type': 'refresh_token',
+            'refresh_token': token.refresh_token,
+        }, headers={
+            'authorization': 'Basic ' + to_base64(
+                    '%s:%s' % (
+                        self.confidential_client.client_id,
+                        self.confidential_client.client_secret
+                    )
+                )
         })
         assert b'access_token' in rv.data
 


### PR DESCRIPTION
*This PR closes #132 and #199*

Section 4.1.3 says "If the client type is confidential or the client was
issued client credentials (or assigned other authentication
requirements), the client MUST authenticate with the authorization
server as described in Section 3.2.1.", and that is HTTP Basic
Authentication.

This commit is based on #292 PR.

@night I have refactored your PR #292 (`request.client_id` and `request.client_secret` are not patched in `_get_client_creds_from_reponse` anymore) and fixed Python 3.x compatibility issues.