### PR TITLE
Allow having access tokens without expiration date

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -786,7 +786,8 @@ class OAuth2RequestValidator(RequestValidator):
             return False
 
         # validate expires
-        if datetime.datetime.utcnow() > tok.expires:
+        if tok.expires is not None and \
+                datetime.datetime.utcnow() > tok.expires:
             msg = 'Bearer token is expired.'
             request.error_message = msg
             log.debug(msg)
@@ -859,7 +860,7 @@ class OAuth2RequestValidator(RequestValidator):
             'authorization_code', 'password',
             'client_credentials', 'refresh_token',
         )
-        
+
         # Grant type is allowed if it is part of the 'allowed_grant_types'
         # of the selected client or if it is one of the default grant types
         if hasattr(client, 'allowed_grant_types'):

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -105,8 +105,10 @@ class Token(db.Model):
     scope = db.Column(db.Text)
 
     def __init__(self, **kwargs):
-        expires_in = kwargs.pop('expires_in')
-        self.expires = datetime.utcnow() + timedelta(seconds=expires_in)
+        expires_in = kwargs.pop('expires_in', None)
+        if expires_in is not None:
+            self.expires = datetime.utcnow() + timedelta(seconds=expires_in)
+
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -232,12 +234,17 @@ def prepare_app(app):
         user_id=1, client_id='dev', access_token='expired', expires_in=0
     )
 
+    access_token2 = Token(
+        user_id=1, client_id='dev', access_token='never_expire'
+    )
+
     try:
         db.session.add(client1)
         db.session.add(client2)
         db.session.add(user)
         db.session.add(temp_grant)
         db.session.add(access_token)
+        db.session.add(access_token2)
         db.session.commit()
     except:
         db.session.rollback()

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -140,6 +140,14 @@ class TestWebAuth(OAuthSuite):
         rv = self.client.get('/method/put')
         assert b'token is expired' in rv.data
 
+    def test_never_expiring_bear_token(self):
+        @self.oauth_client.tokengetter
+        def get_oauth_token():
+            return 'never_expire', ''
+
+        rv = self.client.get('/method/put')
+        assert rv.status_code == 200
+
     def test_get_client(self):
         rv = self.client.post(authorize_url, data={'confirm': 'yes'})
         rv = self.client.get(clean_url(rv.location))


### PR DESCRIPTION
It should be possible to have valid access tokens that doesn't have an
expiration date set. The OAuth RFC recommends having it, but it's not a
requirement. We therefore should only validate expiration date on bearer
token if it's set.

Ref:
https://tools.ietf.org/html/rfc6749#section-4.2.2
https://tools.ietf.org/html/rfc6749#section-5.1