### PR TITLE
Fix non-standard OAuth - Allow content_type to be specified for OAuth1

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -564,7 +564,7 @@ class OAuthRemoteApp(object):
         resp, content = self.http_request(
             uri, headers, method=self.request_token_method,
         )
-        data = parse_response(resp, content)
+        data = parse_response(resp, content, content_type=self.content_type)
         if not data:
             raise OAuthException(
                 'Invalid token response from %s' % self.name,
@@ -613,7 +613,7 @@ class OAuthRemoteApp(object):
             uri, headers, to_bytes(data, self.encoding),
             method=self.access_token_method
         )
-        data = parse_response(resp, content)
+        data = parse_response(resp, content, content_type=self.content_type)
         if resp.code not in (200, 201):
             raise OAuthException(
                 'Invalid response from %s' % self.name,


### PR DESCRIPTION
Allow the content type to be overridden for the OAuth1 flow as described in [Fix non-standard OAuth](https://flask-oauthlib.readthedocs.io/en/latest/client.html#fix-non-standard-oauth).

This seemed to be only active for OAuth2.