### PR TITLE
Added json support to requests.

### DIFF
--- a/flask_oauthlib/utils.py
+++ b/flask_oauthlib/utils.py
@@ -33,7 +33,11 @@ def extract_params():
     if request.authorization:
         headers['Authorization'] = request.authorization
 
-    body = request.form.to_dict()
+    if headers['Content-Type']=='application/json' and request.is_json:
+        body = (request.json)
+    else:
+        body = request.form.to_dict()
+
     return uri, http_method, body, headers
 
 


### PR DESCRIPTION
This allows Content-Type of 'application/json' when POSTing to ouath/token. This change is because Content-Type 'application/x-www-form-urlencoded' is not the standard for most frameworks (that I'm aware of). For my project specifically, this change makes my API Angular2 compatible.