### PR TITLE
Fix "Scopes must be set on post auth"

### DIFF
--- a/example/twitter.py
+++ b/example/twitter.py
@@ -19,7 +19,7 @@ twitter = oauth.remote_app(
     base_url='https://api.twitter.com/1.1/',
     request_token_url='https://api.twitter.com/oauth/request_token',
     access_token_url='https://api.twitter.com/oauth/access_token',
-    authorize_url='https://api.twitter.com/oauth/authenticate',
+    authorize_url='https://api.twitter.com/oauth/authorize'
 )
 
 


### PR DESCRIPTION
Fixes the "Scopes must be set on post auth" error when trying to request the authorization endpoint without specifying the "scope" parameter, as allowed in the OAuth RFC.