### PR TITLE
Allow custom client_secret validation via validate_client_secret()

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -659,6 +659,11 @@ class OAuth2RequestValidator(RequestValidator):
 
         request.client = client
 
+        client_secret_validator = getattr(client, 'validate_client_secret', None)
+        if callable(client_secret_validator) and not client_secret_validator(client_secret):
+            log.debug('Authenticate client failed, invalid secret.')
+            return False
+
         # http://tools.ietf.org/html/rfc6749#section-2
         # The client MAY omit the parameter if the client secret is an empty string.
         if hasattr(client, 'client_secret') and client.client_secret != client_secret:

--- a/tests/oauth2/test_oauth2requestvalidator.py
+++ b/tests/oauth2/test_oauth2requestvalidator.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from flask_oauthlib.provider.oauth2 import OAuth2RequestValidator
+
+
+class TestOAuth2RequestValidator(TestCase):
+    class ClientWithoutSecretValidation(object):
+        pass
+
+    class ClientWithSecretProperty(object):
+        def __init__(self, client_secret):
+            self.__client_secret = client_secret
+
+        @property
+        def client_secret(self):
+            return self.__client_secret
+
+    class ClientWithSecretValidationMethod(object):
+        def __init__(self, client_secret):
+            self.__client_secret = client_secret
+
+        def validate_client_secret(self, client_secret):
+            return client_secret == self.__client_secret
+
+    def setUp(self):
+        self.validator = OAuth2RequestValidator(
+            clientgetter=lambda: {},
+            tokengetter=lambda: {},
+            grantgetter=lambda: {}
+        )
+
+    def test_client_without_client_secret(self):
+        client = self.ClientWithoutSecretValidation()
+        assert self.validator._validate_client_secret(client, None)
+        assert self.validator._validate_client_secret(client, '')
+        assert self.validator._validate_client_secret(client, 'foo')
+
+    def test_client_with_property(self):
+        client = self.ClientWithSecretProperty('foobar')
+        assert self.validator._validate_client_secret(client, 'foobar')
+        assert not self.validator._validate_client_secret(client, 'foo')
+
+    def test_client_with_validation_method(self):
+        client = self.ClientWithSecretValidationMethod('foobar')
+        assert self.validator._validate_client_secret(client, 'foobar')
+        assert not self.validator._validate_client_secret(client, 'foo')

--- a/tests/test_oauth2/base.py
+++ b/tests/test_oauth2/base.py
@@ -67,9 +67,6 @@ class Client(db.Model):
             types.remove(self.disallow_grant_type)
         return types
 
-    def validate_client_secret(self, client_secret):
-        return client_secret == self.client_secret
-
 
 class Grant(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/tests/test_oauth2/base.py
+++ b/tests/test_oauth2/base.py
@@ -67,6 +67,9 @@ class Client(db.Model):
             types.remove(self.disallow_grant_type)
         return types
 
+    def validate_client_secret(self, client_secret):
+        return client_secret == self.client_secret
+
 
 class Grant(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
I do not want to store client secrets as plain text. Therefore I need Flask Authlib to use a custom validation method, that validates the given client secret internally.

This PR adds support for clients providing a custom validation method, as it is already supported for e.g. redirect_uri (via `validate_redirect_uri()`) or scopes (via `validate_scopes()`)