### PR TITLE
Optional token deleter and grant deleter functions

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -348,10 +348,9 @@ class OAuth2Provider(object):
             @oauth.tokendeleter
             def delete_token(access_token=None, refresh_token=None):
                 if access_token:
-                    return token_repository.delete(access_token=access_token)
+                    token_repository.delete(access_token=access_token)
                 if refresh_token:
-                    return token_repository.delete(refresh_token=refresh_token)
-                return None
+                    token_repository.delete(refresh_token=refresh_token)
         """
         self._tokendeleter = f
         return f

--- a/tests/oauth2/server.py
+++ b/tests/oauth2/server.py
@@ -200,6 +200,32 @@ def default_provider(app):
     return oauth
 
 
+def provider_tokendeleter(app):
+    oauth = default_provider(app)
+
+    @oauth.tokendeleter
+    def delete_token(access_token=None, refresh_token=None):
+        if access_token:
+            Token.query.filter_by(access_token=access_token).delete()
+            db.session.commit()
+        if refresh_token:
+            Token.query.filter_by(refresh_token=refresh_token).delete()
+            db.session.commit()
+
+    return oauth
+
+
+def provider_grantdeleter(app):
+    oauth = default_provider(app)
+
+    @oauth.grantdeleter
+    def delete_grant(client_id, code):
+        Grant.query.filter_by(client_id=client_id, code=code).delete()
+        db.session.commit()
+
+    return oauth
+
+
 def prepare_app(app):
     db.init_app(app)
     db.app = app

--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -3,6 +3,8 @@
 import json
 from flask import Flask
 from mock import MagicMock
+
+from tests.oauth2.server import provider_tokendeleter, provider_grantdeleter
 from .server import (
     create_server,
     db,
@@ -182,6 +184,12 @@ class TestWebAuthSQLAlchemy(TestWebAuth):
         return sqlalchemy_provider(app)
 
 
+class TestWebAuthWithCustomGrantDeleter(TestWebAuth):
+
+    def create_oauth_provider(self, app):
+        return provider_grantdeleter(app)
+
+
 class TestRefreshToken(OAuthSuite):
 
     def create_oauth_provider(self, app):
@@ -285,6 +293,12 @@ class TestRevokeTokenCached(TestRefreshToken):
 
     def create_oauth_provider(self, app):
         return cache_provider(app)
+
+
+class TestRevokeTokenWithCustomTokenDeleter(TestRevokeToken):
+
+    def create_oauth_provider(self, app):
+        return provider_tokendeleter(app)
 
 
 class TestRevokeTokenSQLAlchemy(TestRefreshToken):


### PR DESCRIPTION
The current implementation only supports models following the Active Record pattern, which means, the `Token` and the `Grant` models **have to have** a `delete()` method, to delete themselves.

This PR adds support for other model patterns, implementations or levels of abstraction (e.g. Repository Pattern, CQRS, etc.) by allowing the registration of custom functions (`deleter`s), which take care for deleting grants (during the `code` grant/flow)  and tokens (during revokation).

The new functions, which can **optionally** be registered, are called `tokendeleter` and `grantdeleter`, to keep the naming consistent.

Example:
```python
@oauth.grantdeleter
def delete_grant(client_id, code):
    grant_repository.delete(client_id, code)
```