### PR TITLE
remove query string from redirect_uri when comparing

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -713,7 +713,8 @@ class OAuth2RequestValidator(RequestValidator):
             # For testing
             return True
 
-        return grant.redirect_uri == redirect_uri
+        stripped_redirect_uri = (redirect_uri or '').split('?', 1)[0]
+        return grant.redirect_uri == stripped_redirect_uri
 
     def get_original_scopes(self, refresh_token, request, *args, **kwargs):
         """Get the list of scopes associated with the refresh token.


### PR DESCRIPTION
The `request.redirect_uri` could be a url, with query string components, comparison with `grant.redirect_uri` could fail even if the URI parts of two are actually the same.

I may be misunderstanding oauth2 here, I knew so little about it.

@lepture 