### PR TITLE
fix #277, bad exception handle

### DIFF
--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -396,9 +396,11 @@ class OAuth2Provider(object):
                     log.debug('OAuth2Error: %r', e, exc_info=True)
                     return redirect(e.in_uri(redirect_uri))
                 except Exception as e:
-                    log.warning('Exception caught while processing request, %s.' % e, exc_info=True)
+                    log.warning(
+                        'Exception caught while processing request, %s.' % e,
+                        exc_info=True, stack_info=True)
                     return redirect(add_params_to_uri(
-                        self.error_uri, {'error': str(e) }
+                        self.error_uri, {'error': str(e)}
                     ))
 
             else:
@@ -414,12 +416,6 @@ class OAuth2Provider(object):
             except oauth2.OAuth2Error as e:
                 log.debug('OAuth2Error: %r', e, exc_info=True)
                 return redirect(e.in_uri(redirect_uri))
-            except Exception as e:
-                log.warning('Exception caught while processing request, %s.' % e, exc_info=True)
-                return redirect(add_params_to_uri(
-                    self.error_uri, {'error': str(e) }
-                ))
-
 
             if not isinstance(rv, bool):
                 # if is a response or redirect
@@ -460,11 +456,12 @@ class OAuth2Provider(object):
             log.debug('OAuth2Error: %r', e, exc_info=True)
             return redirect(e.in_uri(redirect_uri or self.error_uri))
         except Exception as e:
-            log.warning('Exception caught while processing request, %s.' % e, exc_info=True)
+            log.warning(
+                'Exception caught while processing request, %s.' % e,
+                exc_info=True, stack_info=True)
             return redirect(add_params_to_uri(
-                self.error_uri, {'error': str(e) }
+                self.error_uri, {'error': str(e)}
             ))
-
 
     def verify_request(self, scopes):
         """Verify current request, get the oauth data.

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -396,9 +396,7 @@ class OAuth2Provider(object):
                     log.debug('OAuth2Error: %r', e, exc_info=True)
                     return redirect(e.in_uri(redirect_uri))
                 except Exception as e:
-                    log.warning(
-                        'Exception caught while processing request, %s.' % e,
-                        exc_info=True, stack_info=True)
+                    log.exception(e)
                     return redirect(add_params_to_uri(
                         self.error_uri, {'error': str(e)}
                     ))
@@ -456,9 +454,7 @@ class OAuth2Provider(object):
             log.debug('OAuth2Error: %r', e, exc_info=True)
             return redirect(e.in_uri(redirect_uri or self.error_uri))
         except Exception as e:
-            log.warning(
-                'Exception caught while processing request, %s.' % e,
-                exc_info=True, stack_info=True)
+            log.exception(e)
             return redirect(add_params_to_uri(
                 self.error_uri, {'error': str(e)}
             ))


### PR DESCRIPTION
Remove a `except Exception as e:` which will catch all exception in the view function, add `stack_info=True` to other loggers.