### PR TITLE
adds support for content-type: application/json

### DIFF
--- a/flask_oauthlib/utils.py
+++ b/flask_oauthlib/utils.py
@@ -33,7 +33,11 @@ def extract_params():
     if request.authorization:
         headers['Authorization'] = request.authorization
 
-    body = request.form.to_dict()
+    if 'application/json' == request.content_type:
+        body = request.json
+    else:
+        body = request.form.to_dict()
+
     return uri, http_method, body, headers
 
 


### PR DESCRIPTION
Hi,

I found a discussion about adding support for JSON content [here](https://github.com/lepture/flask-oauthlib/issues/171). Is there any reason other then the `RFC` one, not to implement this? As I write most of my backends based on JSON content, it would be great if I could be consistent there. I couldn't find any work done on this issue so here is my proposal.

Tell me what you think.
Martin  