### PR TITLE
Add support for string type token

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -27,6 +27,12 @@ except ImportError:
 log = logging.getLogger('flask_oauthlib')
 
 
+if PY3:
+    string_types = (str,)
+else:
+    string_types = (str, unicode)
+
+
 __all__ = ('OAuth', 'OAuthRemoteApp', 'OAuthResponse', 'OAuthException')
 
 
@@ -375,8 +381,11 @@ class OAuthRemoteApp(object):
                 **params
             )
         else:
-            if token and isinstance(token, (tuple, list)):
-                token = {'access_token': token[0]}
+            if token:
+                if isinstance(token, (tuple, list)):
+                    token = {'access_token': token[0]}
+                elif isinstance(token, string_types):
+                    token = {'access_token': token}
             client = oauthlib.oauth2.WebApplicationClient(
                 self.consumer_key, token=token
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ from nose.tools import raises
 from flask_oauthlib.client import encode_request_data
 from flask_oauthlib.client import OAuthRemoteApp, OAuth
 from flask_oauthlib.client import parse_response
+from oauthlib.common import PY3
 
 try:
     import urllib2 as http
@@ -184,3 +185,32 @@ class TestOAuthRemoteApp(object):
         resp, content = OAuthRemoteApp.http_request('http://example.com')
         assert resp.code == 404
         assert b'o' in content
+
+    def test_token_types(self):
+        oauth = OAuth()
+        remote = oauth.remote_app('remote',
+                                  consumer_key='remote key',
+                                  consumer_secret='remote secret')
+
+        client_token = {'access_token': 'access token'}
+
+        if not PY3:
+            unicode_token = u'access token'
+            client = remote.make_client(token=unicode_token)
+            assert client.token == client_token
+
+        str_token = 'access token'
+        client = remote.make_client(token=str_token)
+        assert client.token == client_token
+
+        list_token = ['access token']
+        client = remote.make_client(token=list_token)
+        assert client.token == client_token
+
+        tuple_token = ('access token',)
+        client = remote.make_client(token=tuple_token)
+        assert client.token == client_token
+
+        dict_token = {'access_token': 'access token'}
+        client = remote.make_client(token=dict_token)
+        assert client.token == client_token


### PR DESCRIPTION
In the simple use cases, people may only need the access_token, making a tuple/list or dictionary may be excess. With this pr, we can just get the value of `access_token` as a string. Then we can pass it to `request()` method or save it in the database directly. For example:
```python
@app.route('/login/authorized')
def authorized():
    resp = remote.authorized_response()

    access_token = resp['access_token']
    remote.get('user', token=access_token)
    # ...
    user = User(access_token=access_token)  # store into database
    user.save()
    # ...
```
Maybe add an `access_token` parameter same with OAuthlib’s [`Client.access_token`](https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/clients/base.py#L53) is more clear, but for now, I think we can just add an internal support.