### PR TITLE
use requests library for making HTTP requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==0.11.1
 mock==2.0.0
 oauthlib==1.1.2
+requests==2.18.4
 requests-oauthlib==0.6.2
 Flask-SQLAlchemy==2.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,8 @@ from flask_oauthlib.client import encode_request_data
 from flask_oauthlib.client import OAuthRemoteApp, OAuth
 from flask_oauthlib.client import parse_response
 from oauthlib.common import PY3
+import requests
+from requests import Request, Session
 
 try:
     import urllib2 as http
@@ -11,6 +13,8 @@ try:
 except ImportError:
     from urllib import request as http
     http_urlopen = 'urllib.request.urlopen'
+
+http_urlopen = 'requests.Session.send'
 
 from mock import patch
 
@@ -147,7 +151,7 @@ class TestOAuthRemoteApp(object):
         )
 
         resp, content = OAuthRemoteApp.http_request('http://example.com')
-        assert resp.code == 200
+        assert resp.status_code == 200
         assert b'foo' in content
 
         resp, content = OAuthRemoteApp.http_request(


### PR DESCRIPTION
I was receiving URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed when using flask-oauth and have updated it to use the requests library as a fix