### PR TITLE
Pass user into Client.validate_scopes()

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/flask_oauthlib/provider/oauth2.py
+++ b/flask_oauthlib/provider/oauth2.py
@@ -949,7 +949,7 @@ class OAuth2RequestValidator(RequestValidator):
                         *args, **kwargs):
         """Ensure the client is authorized access to requested scopes."""
         if hasattr(client, 'validate_scopes'):
-            return client.validate_scopes(scopes)
+            return client.validate_scopes(scopes, request, *args, **kwargs)
         return set(client.default_scopes).issuperset(set(scopes))
 
     def validate_user(self, username, password, client, request,


### PR DESCRIPTION
This extends `Client.validate_scopes()` to additionally take `request` argument (and, essentially, `request.user`) so both `scopes` and `user` are available in validation/authorization logic.
