### PR TITLE
Bug fix: Preserve "state" parameter in the oauth2 handler when non-critical errors happen as required in RFC 6749.

### DIFF
--- a/tests/oauth2/test_oauth2.py
+++ b/tests/oauth2/test_oauth2.py
@@ -81,12 +81,21 @@ class TestWebAuth(OAuthSuite):
         assert 'code=' in rv.location
         assert 'state' not in rv.location
 
-        # test state
+        # test state on access denied
+        # According to RFC 6749, state should be preserved on error response if it's present in the client request.
+        # Reference: https://tools.ietf.org/html/rfc6749#section-4.1.2
+        rv = self.client.post(authorize_url + '&state=foo', data=dict(
+            confirm='no'
+        ))
+        assert 'error=access_denied' in rv.location
+        assert 'state=foo' in rv.location
+
+        # test state on success
         rv = self.client.post(authorize_url + '&state=foo', data=dict(
             confirm='yes'
         ))
         assert 'code=' in rv.location
-        assert 'state' in rv.location
+        assert 'state=foo' in rv.location
 
     def test_http_head_oauth_authorize_valid_url(self):
         rv = self.client.head(authorize_url)


### PR DESCRIPTION
Changes: Along with "error", "state" is also passed to redirect_uri if it's present on client request.

* Expected behavior: on access_denied, the redirect_uri should be called with error and state if state is present on request
* Actual behavior: only error is passed to redirect_uri and state is always lost.

The PR fixes the bug and make it standard compliant.

Quote from RFC 6749 (https://tools.ietf.org/html/rfc6749#section-4.1.2): 
>    state
         REQUIRED if a "state" parameter was present in the client
         authorization request.  The exact value received from the
         client.
