### PR TITLE
Pin requests-oauthlib version to <1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'Flask',
         'oauthlib>=1.1.2,!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0',
-        'requests-oauthlib>=0.6.2',
+        'requests-oauthlib>=0.6.2,<1.2.0',
     ],
     tests_require=['nose', 'Flask-SQLAlchemy', 'mock'],
     test_suite='nose.collector',


### PR DESCRIPTION
1.2.0 requires oauthlib 3, which we are not compatible with