### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license='BSD',
     install_requires=[
         'Flask',
-        'oauthlib>=1.1.2,!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0',
+        'oauthlib>=1.1.2,!=2.0.3,!=2.0.4,!=2.0.5',
         'requests-oauthlib>=0.6.2,<1.2.0',
     ],
     tests_require=['nose', 'Flask-SQLAlchemy', 'mock'],


### PR DESCRIPTION
Could not find a version that matches oauthlib!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0,>=1.1.2,>=3.0.0 (from Flask-OAuthlib==0.9.5->-r app/requirements.in (line 5))
Tried: 0.0.1, 0.0.2, 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.3.0, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.4.0, 0.4.1, 0.4.2, 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.7.0, 0.7.1, 0.7.2, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.1.0.post1, 1.1.1, 1.1.2, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.7, 2.1.0, 2.1.0, 3.0.0, 3.0.0, 3.0.1, 3.0.1, 3.0.2, 3.0.2, 3.1.0, 3.1.0
There are incompatible versions in the resolved dependencies:
  oauthlib!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0,>=1.1.2 (from Flask-OAuthlib==0.9.5->-r app/requirements.in (line 5))
  oauthlib>=3.0.0 (from requests-oauthlib==1.2.0->Flask-OAuthlib==0.9.5->-r app/requirements.in (line 5))