### PR TITLE
Update Auth0 sponsorship link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,13 @@ Sponsored by
 ------------
 
 If you want to quickly add secure authentication to Flask, feel free to
-check out Auth0's Python API SDK and free plan at `auth0.com/overview`_
+check out Auth0's Python API SDK and free plan at `auth0.com/developers`_
 |auth0 image|
 
-.. _`auth0.com/overview`: https://auth0.com/overview?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=flask-oauthlib&utm_content=auth
+.. _`auth0.com/developers`: https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=flask-oauthlib&utm_content=auth
 
 .. |auth0 image| image:: https://user-images.githubusercontent.com/290496/31718461-031a6710-b44b-11e7-80f8-7c5920c73b8f.png
-   :target: https://auth0.com/overview?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=flask-oauthlib&utm_content=auth
+   :target: https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=flask-oauthlib&utm_content=auth
    :alt: Coverage Status
    :width: 18px
    :height: 18px


### PR DESCRIPTION
Hey

We recently launched a new page specifically geared towards developers on auth0.com.
Can we change the link in the sponsorship message?

Thanks again for your open-source work!