### PR TITLE
Travis-ci: added support for ppc64le along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: python
-
+arch:
+  - amd64
+  - ppc64le
 python:
     - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
     - "pypy"
+
+matrix:
+   exclude:
+      - python: "pypy"
+        arch: ppc64le
 
 script:
     - nosetests -s
@@ -18,6 +25,7 @@ after_success:
 branches:
   only:
     - master
+    - ppc64le
 
 notifications:
     email: false


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/flask-oauthlib/builds/189444511 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!