### PR TITLE
docs: fix simple typo, usally -> usually

### DIFF
--- a/docs/oauth1.rst
+++ b/docs/oauth1.rst
@@ -28,7 +28,7 @@ To implemente the oauthorization flow, we need to understand the data model.
 User (Resource Owner)
 ---------------------
 
-A user, or resource owner, is usally the registered user on your site. You
+A user, or resource owner, is usually the registered user on your site. You
 design your own user model, there is not much to say.
 
 


### PR DESCRIPTION
There is a small typo in docs/oauth1.rst.

Should read `usually` rather than `usally`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md