### PR TITLE
Use https instead of git in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/lepture/flask-sphinx-themes.git
+	url = https://github.com/lepture/flask-sphinx-themes.git


### PR DESCRIPTION
This fixes the recent deprecation of unencrypted repo access in GitHub